### PR TITLE
mtk: raise buffer size for Snapdragon

### DIFF
--- a/src/mtk.cpp
+++ b/src/mtk.cpp
@@ -113,7 +113,7 @@ errout:
 int
 GPSDriverMTK::receive(unsigned timeout)
 {
-	uint8_t buf[32];
+	uint8_t buf[128];
 	gps_mtk_packet_t packet;
 
 	/* timeout additional to poll */


### PR DESCRIPTION
On QURT there is a warning coming up that the buffer size is
too small.  This change should silence it.