### PR TITLE
Navio: Add support for SPI-connected GPS

### DIFF
--- a/src/gps_helper.h
+++ b/src/gps_helper.h
@@ -122,6 +122,12 @@ public:
 		RTCM        ///< request RTCM output. This is used for (fixed position) base stations
 	};
 
+	enum class Interface {
+		UART = 0,
+		SPI
+	};
+
+
 	GPSHelper(GPSCallbackPtr callback, void *callback_user);
 	virtual ~GPSHelper();
 

--- a/src/gps_helper.h
+++ b/src/gps_helper.h
@@ -122,12 +122,6 @@ public:
 		RTCM        ///< request RTCM output. This is used for (fixed position) base stations
 	};
 
-	enum class Interface {
-		UART = 0,
-		SPI
-	};
-
-
 	GPSHelper(GPSCallbackPtr callback, void *callback_user);
 	virtual ~GPSHelper();
 

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -77,7 +77,7 @@
 #define UBX_WARN(...)		{GPS_WARN(__VA_ARGS__);}
 #define UBX_DEBUG(...)		{/*GPS_WARN(__VA_ARGS__);*/}
 
-GPSDriverUBX::GPSDriverUBX(Interface interface, GPSCallbackPtr callback, void *callback_user,
+GPSDriverUBX::GPSDriverUBX(gps_interface interface, GPSCallbackPtr callback, void *callback_user,
 			   struct vehicle_gps_position_s *gps_position,
 			   struct satellite_info_s *satellite_info) :
 	GPSHelper(callback, callback_user),
@@ -128,7 +128,7 @@ GPSDriverUBX::configure(unsigned &baudrate, OutputMode output_mode)
 	//better way to check the protocol version?
 
 
-	if (_interface == GPSHelper::Interface::UART) {
+	if (_interface == INTERFACE_UART) {
 		for (baud_i = 0; baud_i < sizeof(baudrates) / sizeof(baudrates[0]); baud_i++) {
 			baudrate = baudrates[baud_i];
 			setBaudrate(baudrate);
@@ -194,7 +194,7 @@ GPSDriverUBX::configure(unsigned &baudrate, OutputMode output_mode)
 			return -1;	// connection and/or baudrate detection failed
 		}
 
-	} else if (_interface == GPSHelper::Interface::SPI) {
+	} else if (_interface == INTERFACE_SPI) {
 		memset(cfg_prt, 0, 2 * sizeof(ubx_payload_tx_cfg_prt_t));
 		cfg_prt[0].portID		= UBX_TX_CFG_PRT_PORTID_SPI;
 		cfg_prt[0].mode			= UBX_TX_CFG_PRT_MODE_SPI;
@@ -1404,4 +1404,3 @@ GPSDriverUBX::fnv1_32_str(uint8_t *str, uint32_t hval)
 	/* return our new hash value */
 	return hval;
 }
-

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -145,11 +145,8 @@
 #define UBX_TX_CFG_PRT_PORTID		0x01		/**< UART1 */
 #define UBX_TX_CFG_PRT_PORTID_USB	0x03		/**< USB */
 #define UBX_TX_CFG_PRT_PORTID_SPI	0x04		/**< SPI */
-#if !defined(__PX4_POSIX_RPI)
 #define UBX_TX_CFG_PRT_MODE		0x000008D0	/**< 0b0000100011010000: 8N1 */
-#else
-#define UBX_TX_CFG_PRT_MODE		0x00003200
-#endif
+#define UBX_TX_CFG_PRT_MODE_SPI	0x00000100
 #define UBX_TX_CFG_PRT_BAUDRATE		38400		/**< choose 38400 as GPS baudrate */
 #define UBX_TX_CFG_PRT_INPROTOMASK_GPS	((1<<5) | 0x01)	/**< RTCM3 in and UBX in */
 #define UBX_TX_CFG_PRT_INPROTOMASK_RTCM	(0x01)	/**< UBX in */
@@ -572,7 +569,8 @@ typedef enum {
 class GPSDriverUBX : public GPSHelper
 {
 public:
-	GPSDriverUBX(GPSCallbackPtr callback, void *callback_user, struct vehicle_gps_position_s *gps_position,
+	GPSDriverUBX(Interface interface, GPSCallbackPtr callback, void *callback_user,
+		     struct vehicle_gps_position_s *gps_position,
 		     struct satellite_info_s *satellite_info);
 	virtual ~GPSDriverUBX();
 	int receive(unsigned timeout);
@@ -668,6 +666,8 @@ private:
 	OutputMode		_output_mode = OutputMode::GPS;
 
 	rtcm_message_t	*_rtcm_message = nullptr;
+
+	Interface		_interface;
 };
 
 #endif /* UBX_H_ */

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -569,9 +569,9 @@ typedef enum {
 class GPSDriverUBX : public GPSHelper
 {
 public:
-	GPSDriverUBX(Interface interface, GPSCallbackPtr callback, void *callback_user,
-		     struct vehicle_gps_position_s *gps_position,
-		     struct satellite_info_s *satellite_info);
+	GPSDriverUBX(gps_interface interface, GPSCallbackPtr callback, void *callback_user,
+			 struct vehicle_gps_position_s *gps_position,
+			 struct satellite_info_s *satellite_info);
 	virtual ~GPSDriverUBX();
 	int receive(unsigned timeout);
 	int configure(unsigned &baudrate, OutputMode output_mode);
@@ -667,7 +667,7 @@ private:
 
 	rtcm_message_t	*_rtcm_message = nullptr;
 
-	Interface		_interface;
+	gps_interface		_interface;
 };
 
 #endif /* UBX_H_ */

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -144,7 +144,12 @@
 /* TX CFG-PRT message contents */
 #define UBX_TX_CFG_PRT_PORTID		0x01		/**< UART1 */
 #define UBX_TX_CFG_PRT_PORTID_USB	0x03		/**< USB */
+#define UBX_TX_CFG_PRT_PORTID_SPI	0x04		/**< SPI */
+#if !defined(__PX4_POSIX_RPI)
 #define UBX_TX_CFG_PRT_MODE		0x000008D0	/**< 0b0000100011010000: 8N1 */
+#else
+#define UBX_TX_CFG_PRT_MODE		0x00003200
+#endif
 #define UBX_TX_CFG_PRT_BAUDRATE		38400		/**< choose 38400 as GPS baudrate */
 #define UBX_TX_CFG_PRT_INPROTOMASK_GPS	((1<<5) | 0x01)	/**< RTCM3 in and UBX in */
 #define UBX_TX_CFG_PRT_INPROTOMASK_RTCM	(0x01)	/**< UBX in */


### PR DESCRIPTION
This adds support for a U-blox GPS device on SPI bus. This needs another PR for the Firmware.