### PR TITLE
Untested: UBX driver: Reset module as part of config

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -127,13 +127,35 @@ GPSDriverUBX::configure(unsigned &baudrate, OutputMode output_mode)
 		for (baud_i = 0; baud_i < sizeof(baudrates) / sizeof(baudrates[0]); baud_i++) {
 			unsigned test_baudrate = baudrates[baud_i];
 
+			UBX_DEBUG("baudrate set to %i", test_baudrate);
+
 			if (baudrate > 0 && baudrate != test_baudrate) {
 				continue; // skip to next baudrate
 			}
 
 			setBaudrate(test_baudrate);
 
-			UBX_DEBUG("baudrate set to %i", test_baudrate);
+			/* reset all configuration on the module - this is necessary as some vendors lock
+			 * lock bad configurations
+			 */
+			ubx_payload_tx_cfg_cfg_t cfg_cfg = {};
+			cfg_cfg.clearMask = ((1 << 12) | (1 << 11) | (1 << 10) | (1 << 9) |
+					     (1 << 8) | (1 << 4) | (1 << 3) | (1 << 2) | (1 << 1) | (1 << 0));
+			cfg_cfg.deviceMask = (1 << 2) | (1 << 1) | (1 << 0);
+
+			if (!sendMessage(UBX_MSG_CFG_CFG, (uint8_t *)&cfg_cfg, sizeof(ubx_payload_tx_cfg_cfg_t))) {
+				UBX_DEBUG("cfg reset: UART TX failed");
+			}
+
+			if (waitForAck(UBX_MSG_CFG_CFG, UBX_CONFIG_TIMEOUT, true) < 0) {
+				UBX_DEBUG("cfg reset failed");
+
+			} else {
+				UBX_DEBUG("cfg reset ACK");
+			}
+
+			/* allow the module to re-initialize */
+			usleep(200000);
 
 			/* flush input and wait for at least 20 ms silence */
 			decodeInit();

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2018 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -83,6 +83,7 @@
 #define UBX_ID_CFG_PRT		0x00
 #define UBX_ID_CFG_MSG		0x01
 #define UBX_ID_CFG_RATE		0x08
+#define UBX_ID_CFG_CFG		0x09
 #define UBX_ID_CFG_NAV5		0x24
 #define UBX_ID_CFG_SBAS		0x16
 #define UBX_ID_CFG_TMODE3	0x71
@@ -112,6 +113,7 @@
 #define UBX_MSG_CFG_PRT		((UBX_CLASS_CFG) | UBX_ID_CFG_PRT << 8)
 #define UBX_MSG_CFG_MSG		((UBX_CLASS_CFG) | UBX_ID_CFG_MSG << 8)
 #define UBX_MSG_CFG_RATE	((UBX_CLASS_CFG) | UBX_ID_CFG_RATE << 8)
+#define UBX_MSG_CFG_CFG		((UBX_CLASS_CFG) | UBX_ID_CFG_CFG << 8)
 #define UBX_MSG_CFG_NAV5	((UBX_CLASS_CFG) | UBX_ID_CFG_NAV5 << 8)
 #define UBX_MSG_CFG_SBAS	((UBX_CLASS_CFG) | UBX_ID_CFG_SBAS << 8)
 #define UBX_MSG_CFG_TMODE3	((UBX_CLASS_CFG) | UBX_ID_CFG_TMODE3 << 8)
@@ -432,6 +434,14 @@ typedef struct {
 	uint16_t	timeRef;	/**< Alignment to reference time: 0 = UTC time, 1 = GPS time */
 } ubx_payload_tx_cfg_rate_t;
 
+/* Tx CFG-CFG */
+typedef struct {
+	uint32_t	clearMask;	/**< Clear settings */
+	uint32_t	saveMask;	/**< Save settings */
+	uint32_t	loadMask;	/**< Load settings */
+	uint8_t		deviceMask; /**< Storage devices to apply this top */
+} ubx_payload_tx_cfg_cfg_t;
+
 /* Tx CFG-NAV5 */
 typedef struct {
 	uint16_t	mask;
@@ -518,6 +528,7 @@ typedef union {
 	ubx_payload_tx_cfg_sbas_t		payload_tx_cfg_sbas;
 	ubx_payload_tx_cfg_msg_t		payload_tx_cfg_msg;
 	ubx_payload_tx_cfg_tmode3_t		payload_tx_cfg_tmode3;
+	ubx_payload_tx_cfg_cfg_t		payload_tx_cfg_cfg;
 } ubx_buf_t;
 
 #pragma pack(pop)


### PR DESCRIPTION
@bkueng @sirPerna This should fix the issues with pre-configured GPS modules which do not accept serial config commands. I don't have one of these modules so I need to test this first. Matching Firmware PR:

https://github.com/PX4/Firmware/pull/6171