### PR TITLE
ubx: fix time_utc_usec, if NAV-PVT message received

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -1023,7 +1023,7 @@ GPSDriverUBX::payloadRxDone()
 				setClock(ts);
 
 				_gps_position->time_utc_usec = static_cast<uint64_t>(epoch) * 1000000ULL;
-				_gps_position->time_utc_usec += _buf.payload_rx_nav_timeutc.nano / 1000;
+				_gps_position->time_utc_usec += _buf.payload_rx_nav_pvt.nano / 1000;
 
 			} else {
 				_gps_position->time_utc_usec = 0;


### PR DESCRIPTION
_buf contains a payload_rx_nav_pvt, but we accessed it as
payload_rx_nav_timeutc (copy-paste mistake).