### PR TITLE
Add Trimble MB-Two GPS support

### DIFF
--- a/src/ashtech.cpp
+++ b/src/ashtech.cpp
@@ -51,10 +51,11 @@
 
 GPSDriverAshtech::GPSDriverAshtech(GPSCallbackPtr callback, void *callback_user,
 				   struct vehicle_gps_position_s *gps_position,
-				   struct satellite_info_s *satellite_info) :
+				   struct satellite_info_s *satellite_info, float heading_offset) :
 	GPSHelper(callback, callback_user),
 	_satellite_info(satellite_info),
-	_gps_position(gps_position)
+	_gps_position(gps_position),
+	_heading_offset(heading_offset)
 {
 	decodeInit();
 }
@@ -287,10 +288,16 @@ int GPSDriverAshtech::handleMessage(int len)
 		if (bufptr && *(++bufptr) != ',') {
 			heading = strtof(bufptr, &endp); bufptr = endp;
 
-			ASH_DEBUG("heading: %.3f", (double)heading);
+			ASH_DEBUG("heading update: %.3f", (double)heading);
 
-			heading *= M_PI_F / 180.0f; // deg to rad, now in range [0, 2PI]
-			// TODO: return the value
+			heading *= M_PI_F / 180.0f; // deg to rad, now in range [0, 2pi]
+			heading += _heading_offset; // range: [-pi, 3pi]
+
+			if (heading > M_PI_F) {
+				heading -= 2.f * M_PI_F; // final range is [-pi, pi]
+			}
+
+			_gps_position->heading = heading;
 		}
 
 	} else if ((memcmp(_rx_buffer, "$PASHR,POS,", 11) == 0) && (uiCalcComma == 18)) {

--- a/src/ashtech.cpp
+++ b/src/ashtech.cpp
@@ -404,7 +404,19 @@ int GPSDriverAshtech::handleMessage(int len)
 			_gps_position->fix_type = 0;
 
 		} else {
-			_gps_position->fix_type = 3 + fix_quality;
+			if (fix_quality == 9 || fix_quality == 10) { // SBAS differential or BeiDou differential
+				_gps_position->fix_type = 4; // use RTCM differential
+
+			} else if (fix_quality == 12 || fix_quality == 22) { // RTK float or RTK float dithered
+				_gps_position->fix_type = 5;
+
+			} else if (fix_quality == 13 || fix_quality == 23) { // RTK fixed or RTK fixed dithered
+				_gps_position->fix_type = 6;
+
+			} else {
+				_gps_position->fix_type = 3 + fix_quality;
+			}
+
 		}
 
 		_gps_position->timestamp = gps_absolute_time();

--- a/src/ashtech.cpp
+++ b/src/ashtech.cpp
@@ -667,9 +667,9 @@ int GPSDriverAshtech::handleMessage(int len)
 				};
 
 				for (unsigned int conf_i = 0; conf_i < sizeof(rtcm_options) / sizeof(rtcm_options[0]); conf_i++) {
-					int len = snprintf(buffer, sizeof(buffer), rtcm_options[conf_i], _port);
+					int str_len = snprintf(buffer, sizeof(buffer), rtcm_options[conf_i], _port);
 
-					if (writeAckedCommand(buffer, len, ASH_RESPONSE_TIMEOUT) != 0) {
+					if (writeAckedCommand(buffer, str_len, ASH_RESPONSE_TIMEOUT) != 0) {
 						ASH_DEBUG("command %s failed", buffer);
 					}
 				}

--- a/src/ashtech.cpp
+++ b/src/ashtech.cpp
@@ -402,8 +402,8 @@ int GPSDriverAshtech::handleMessage(int len)
 		_gps_position->lat = static_cast<int>((int(lat * 0.01) + (lat * 0.01 - int(lat * 0.01)) * 100.0 / 60.0) * 10000000);
 		_gps_position->lon = static_cast<int>((int(lon * 0.01) + (lon * 0.01 - int(lon * 0.01)) * 100.0 / 60.0) * 10000000);
 		_gps_position->alt = static_cast<int>(alt * 1000);
-		_gps_position->hdop = (float)hdop / 100.0f;
-		_gps_position->vdop = (float)vdop / 100.0f;
+		_gps_position->hdop = (float)hdop;
+		_gps_position->vdop = (float)vdop;
 		_rate_count_lat_lon++;
 
 		if (coordinatesFound < 3) {

--- a/src/ashtech.h
+++ b/src/ashtech.h
@@ -49,8 +49,11 @@ class RTCMParsing;
 class GPSDriverAshtech : public GPSHelper
 {
 public:
+	/**
+	 * @param heading_offset heading offset in radians [-pi, pi]. It is added to the measurement.
+	 */
 	GPSDriverAshtech(GPSCallbackPtr callback, void *callback_user, struct vehicle_gps_position_s *gps_position,
-			 struct satellite_info_s *satellite_info);
+			 struct satellite_info_s *satellite_info, float heading_offset = 0.f);
 	virtual ~GPSDriverAshtech();
 
 	int receive(unsigned timeout);
@@ -131,5 +134,7 @@ private:
 	OutputMode _output_mode{OutputMode::GPS};
 	bool _correction_output_activated{false};
 	bool _configure_done{false};
+
+	float _heading_offset;
 };
 

--- a/src/ashtech.h
+++ b/src/ashtech.h
@@ -65,23 +65,20 @@ private:
 	/** Read char ASHTECH parameter */
 	char read_char();
 
-	enum ashtech_decode_state_t {
-		NME_DECODE_UNINIT,
-		NME_DECODE_GOT_SYNC1,
-		NME_DECODE_GOT_ASTERIKS,
-		NME_DECODE_GOT_FIRST_CS_BYTE
+	enum class NMEADecodeState {
+		uninit,
+		got_sync1,
+		got_asteriks,
+		got_first_cs_byte
 	};
 
 	struct satellite_info_s *_satellite_info {nullptr};
 	struct vehicle_gps_position_s *_gps_position {nullptr};
 	uint64_t _last_timestamp_time{0};
-	int _ashtechlog_fd{-1};
 
-	ashtech_decode_state_t _decode_state{NME_DECODE_UNINIT};
-	uint8_t _rx_buffer[ASHTECH_RECV_BUFFER_SIZE] {};
+	NMEADecodeState _decode_state{NMEADecodeState::uninit};
+	uint8_t _rx_buffer[ASHTECH_RECV_BUFFER_SIZE];
 	uint16_t _rx_buffer_bytes{};
 	bool _got_pashr_pos_message{false}; /**< If we got a PASHR,POS message, we will ignore GGA messages */
-	bool _parse_error{}; /**< parse error flag */
-	char *_parse_pos{}; /**< parse position */
 };
 

--- a/src/ashtech.h
+++ b/src/ashtech.h
@@ -56,11 +56,13 @@ public:
 	int receive(unsigned timeout);
 	int configure(unsigned &baudrate, OutputMode output_mode);
 
+	void setSurveyInSpecs(uint32_t survey_in_acc_limit, uint32_t survey_in_min_dur) override;
 private:
 	enum class NMEACommand {
 		Acked, // Command that returns a (N)Ack
 		PRT,   // port config
-		RID    // board identification
+		RID,   // board identification
+		RECEIPT// board identification
 	};
 
 	enum class NMEACommandState {
@@ -100,6 +102,13 @@ private:
 	 */
 	void receiveWait(unsigned timeout_min);
 
+	/**
+	 * enable output of correction output
+	 */
+	void activateCorrectionOutput();
+
+	void sendSurveyInStatusUpdate(bool active, bool valid);
+
 	struct satellite_info_s *_satellite_info {nullptr};
 	struct vehicle_gps_position_s *_gps_position {nullptr};
 	uint64_t _last_timestamp_time{0};
@@ -116,6 +125,11 @@ private:
 
 	RTCMParsing	*_rtcm_parsing{nullptr};
 
+	uint32_t _survey_in_min_dur;
+	gps_abstime _survey_in_start{0};
+
 	OutputMode _output_mode{OutputMode::GPS};
+	bool _correction_output_activated{false};
+	bool _configure_done{false};
 };
 

--- a/src/ashtech.h
+++ b/src/ashtech.h
@@ -40,6 +40,8 @@
 #include "gps_helper.h"
 #include "../../definitions.h"
 
+class RTCMParsing;
+
 #define ASHTECH_RECV_BUFFER_SIZE 512
 
 #define ASH_RESPONSE_TIMEOUT	200		// ms, timeout for waiting for a response
@@ -49,7 +51,7 @@ class GPSDriverAshtech : public GPSHelper
 public:
 	GPSDriverAshtech(GPSCallbackPtr callback, void *callback_user, struct vehicle_gps_position_s *gps_position,
 			 struct satellite_info_s *satellite_info);
-	virtual ~GPSDriverAshtech() = default;
+	virtual ~GPSDriverAshtech();
 
 	int receive(unsigned timeout);
 	int configure(unsigned &baudrate, OutputMode output_mode);
@@ -72,7 +74,8 @@ private:
 		uninit,
 		got_sync1,
 		got_asteriks,
-		got_first_cs_byte
+		got_first_cs_byte,
+		decode_rtcm3
 	};
 
 	enum class AshtechBoard {
@@ -107,8 +110,12 @@ private:
 	bool _got_pashr_pos_message{false}; /**< If we got a PASHR,POS message, we will ignore GGA messages */
 
 	NMEACommand _waiting_for_command;
-	NMEACommandState _command_state;
+	NMEACommandState _command_state{NMEACommandState::idle};
 	char _port{'A'}; /**< port we are connected to (e.g. 'A') */
 	AshtechBoard _board{AshtechBoard::other}; /**< board we are connected to */
+
+	RTCMParsing	*_rtcm_parsing{nullptr};
+
+	OutputMode _output_mode{OutputMode::GPS};
 };
 

--- a/src/gps_helper.h
+++ b/src/gps_helper.h
@@ -134,7 +134,8 @@ public:
 
 	/**
 	 * configure the device
-	 * @param baud will be set to the baudrate (output parameter)
+	 * @param baud Input and output parameter: if set to 0, the baudrate will be automatically detected and set to
+	 *             the detected baudrate. If not 0, a fixed baudrate is used.
 	 * @return 0 on success, <0 otherwise
 	 */
 	virtual int configure(unsigned &baud, OutputMode output_mode) = 0;

--- a/src/gps_helper.h
+++ b/src/gps_helper.h
@@ -154,13 +154,6 @@ public:
 	void storeUpdateRates();
 
 	/**
-	 * Start or restart the survey-in procees. This is only used in RTCM ouput mode.
-	 * It will be called automatically after configuring.
-	 * @return 0 on success, <0 on error
-	 */
-	virtual int restartSurveyIn() { return 0; }
-
-	/**
 	 * set survey-in specs for RTK base station setup (for finding an accurate base station position
 	 * by averaging the position measurements over time).
 	 * @param survey_in_acc_limit minimum accuracy in 0.1mm

--- a/src/gps_helper.h
+++ b/src/gps_helper.h
@@ -160,6 +160,17 @@ public:
 	 */
 	virtual int restartSurveyIn() { return 0; }
 
+	/**
+	 * set survey-in specs for RTK base station setup (for finding an accurate base station position
+	 * by averaging the position measurements over time).
+	 * @param survey_in_acc_limit minimum accuracy in 0.1mm
+	 * @param survey_in_min_dur minimum duration in seconds
+	 */
+	virtual void setSurveyInSpecs(uint32_t survey_in_acc_limit, uint32_t survey_in_min_dur)
+	{
+		(void)survey_in_acc_limit;
+		(void)survey_in_min_dur;
+	}
 
 protected:
 

--- a/src/mtk.cpp
+++ b/src/mtk.cpp
@@ -62,6 +62,10 @@ GPSDriverMTK::configure(unsigned &baudrate, OutputMode output_mode)
 		return -1;
 	}
 
+	if (baudrate > 0 && baudrate != MTK_BAUDRATE) {
+		return -1;
+	}
+
 	/* set baudrate first */
 	if (GPSHelper::setBaudrate(MTK_BAUDRATE) != 0) {
 		return -1;

--- a/src/rtcm.cpp
+++ b/src/rtcm.cpp
@@ -1,0 +1,78 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "rtcm.h"
+#include <cstring>
+
+RTCMParsing::RTCMParsing()
+{
+	reset();
+}
+
+RTCMParsing::~RTCMParsing()
+{
+	if (_buffer) {
+		delete[](_buffer);
+	}
+}
+
+void RTCMParsing::reset()
+{
+	if (!_buffer) {
+		_buffer = new uint8_t[RTCM_INITIAL_BUFFER_LENGTH];
+		_buffer_len = RTCM_INITIAL_BUFFER_LENGTH;
+	}
+
+	_pos = 0;
+	_message_length = _buffer_len;
+}
+
+bool RTCMParsing::addByte(uint8_t b)
+{
+	_buffer[_pos++] = b;
+
+	if (_pos == 3) {
+		_message_length = (((uint16_t)_buffer[1] & 3) << 8) | (_buffer[2]);
+
+		if (_message_length + 6 > _buffer_len) {
+			uint16_t new_buffer_len = _message_length + 6;
+			uint8_t *new_buffer = new uint8_t[new_buffer_len];
+			memcpy(new_buffer, _buffer, 3);
+			delete[](_buffer);
+			_buffer = new_buffer;
+			_buffer_len = new_buffer_len;
+		}
+	}
+
+	return _message_length + 6 == _pos;
+}

--- a/src/rtcm.h
+++ b/src/rtcm.h
@@ -1,0 +1,69 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+/* RTCM3 */
+#define RTCM3_PREAMBLE					0xD3
+#define RTCM_INITIAL_BUFFER_LENGTH			300		/**< initial maximum message length of an RTCM message */
+
+
+class RTCMParsing
+{
+public:
+	RTCMParsing();
+	~RTCMParsing();
+
+	/**
+	 * reset the parsing state
+	 */
+	void reset();
+
+	/**
+	 * add a byte to the message
+	 * @param b
+	 * @return true if message complete (use @message to get it)
+	 */
+	bool addByte(uint8_t b);
+
+	uint8_t *message() const { return _buffer; }
+	uint16_t messageLength() const { return _pos; }
+
+private:
+	uint8_t			*_buffer{nullptr};
+	uint16_t		_buffer_len;
+	uint16_t		_pos;						///< next position in buffer
+	uint16_t		_message_length;					///< message length without header & CRC (both 3 bytes)
+};

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -172,16 +172,7 @@
 #define UBX_TX_CFG_TMODE3_SVINMINDUR    (3*60)		/**< survey-in: minimum duration [s] (higher=higher precision) */
 #define UBX_TX_CFG_TMODE3_SVINACCLIMIT  (10000)	/**< survey-in: position accuracy limit 0.1[mm] */
 
-/* RTCM3 */
-#define RTCM3_PREAMBLE					0xD3
-#define RTCM_INITIAL_BUFFER_LENGTH			300		/**< initial maximum message length of an RTCM message */
-
-typedef struct {
-	uint8_t			*buffer;
-	uint16_t		buffer_len;
-	uint16_t		pos;						///< next position in buffer
-	uint16_t		message_length;					///< message length without header & CRC (both 3 bytes)
-} rtcm_message_t;
+class RTCMParsing;
 
 
 /*** u-blox protocol binary message and payload definitions ***/
@@ -668,7 +659,7 @@ private:
 	bool			_use_nav_pvt{false};
 	OutputMode		_output_mode{OutputMode::GPS};
 
-	rtcm_message_t	*_rtcm_message{nullptr};
+	RTCMParsing	*_rtcm_parsing{nullptr};
 
 	const Interface		_interface;
 	uint32_t _survey_in_acc_limit;

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -568,10 +568,15 @@ public:
 	int receive(unsigned timeout) override;
 	int configure(unsigned &baudrate, OutputMode output_mode) override;
 
-	int restartSurveyIn() override;
-
 	void setSurveyInSpecs(uint32_t survey_in_acc_limit, uint32_t survey_in_min_dur) override;
 private:
+
+	/**
+	 * Start or restart the survey-in procees. This is only used in RTCM ouput mode.
+	 * It will be called automatically after configuring.
+	 * @return 0 on success, <0 on error
+	 */
+	int restartSurveyIn();
 
 	/**
 	 * Parse the binary UBX packet

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -570,7 +570,7 @@ public:
 
 	int restartSurveyIn() override;
 
-	void setSurveyInSpecs(uint32_t survey_in_acc_limit, uint32_t survey_in_min_dur);
+	void setSurveyInSpecs(uint32_t survey_in_acc_limit, uint32_t survey_in_min_dur) override;
 private:
 
 	/**


### PR DESCRIPTION
This adds heading and RTK support for the Trimble MB-Two using the Ashtech driver (including base station survey-in).
The MB-Two is expected to have 2 antennas attached, which is then used to compute a heading angle.

I had some problems with auto-detection when the baudrate changed - the device became unresponsive for 10's of seconds. This is why the baudrate can now be set to a fixed value. However my latest tests showed that this is much better now, I'm not sure why. I'll do further testing, but this can still be merged as is.

Further changes are explained in the individual commits.

I have not tested it on another Ashtech GPS device, since I don't have any.