### PR TITLE
Base station: add ability to directly set the position

### DIFF
--- a/src/ashtech.h
+++ b/src/ashtech.h
@@ -33,12 +33,14 @@
  *
  ****************************************************************************/
 
-/* @file ASHTECH protocol definitions */
+/** @file ASHTECH protocol definitions */
 
 #pragma once
 
 #include "gps_helper.h"
+#include "base_station.h"
 #include "../../definitions.h"
+#include <cmath>
 
 class RTCMParsing;
 
@@ -46,7 +48,7 @@ class RTCMParsing;
 
 #define ASH_RESPONSE_TIMEOUT	200		// ms, timeout for waiting for a response
 
-class GPSDriverAshtech : public GPSHelper
+class GPSDriverAshtech : public GPSBaseStationSupport
 {
 public:
 	/**
@@ -59,7 +61,6 @@ public:
 	int receive(unsigned timeout) override;
 	int configure(unsigned &baudrate, OutputMode output_mode) override;
 
-	void setSurveyInSpecs(uint32_t survey_in_acc_limit, uint32_t survey_in_min_dur) override;
 private:
 	enum class NMEACommand {
 		Acked, // Command that returns a (N)Ack
@@ -110,7 +111,10 @@ private:
 	 */
 	void activateCorrectionOutput();
 
-	void sendSurveyInStatusUpdate(bool active, bool valid);
+	void sendSurveyInStatusUpdate(bool active, bool valid, double latitude = NAN, double longitude = NAN,
+				      float altitude = NAN);
+
+	void activateRTCMOutput();
 
 	struct satellite_info_s *_satellite_info {nullptr};
 	struct vehicle_gps_position_s *_gps_position {nullptr};
@@ -128,7 +132,6 @@ private:
 
 	RTCMParsing	*_rtcm_parsing{nullptr};
 
-	uint32_t _survey_in_min_dur;
 	gps_abstime _survey_in_start{0};
 
 	OutputMode _output_mode{OutputMode::GPS};

--- a/src/base_station.h
+++ b/src/base_station.h
@@ -1,0 +1,112 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file base_station.h
+ *
+ * @author Beat Küng <beat-kueng@gmx.net>
+ *
+ */
+
+#pragma once
+
+#include "gps_helper.h"
+
+/**
+ * @class GPSBaseStationSupport
+ * GPS driver base class with Base Station Support
+ */
+class GPSBaseStationSupport : public GPSHelper
+{
+public:
+	GPSBaseStationSupport(GPSCallbackPtr callback, void *callback_user)
+		: GPSHelper(callback, callback_user) {}
+
+	virtual ~GPSBaseStationSupport() = default;
+
+	/**
+	 * set survey-in specs for RTK base station setup (for finding an accurate base station position
+	 * by averaging the position measurements over time).
+	 * @param survey_in_acc_limit minimum accuracy in 0.1mm
+	 * @param survey_in_min_dur minimum duration in seconds
+	 */
+	void setSurveyInSpecs(uint32_t survey_in_acc_limit, uint32_t survey_in_min_dur)
+	{
+		_base_settings.type = BaseSettingsType::survey_in;
+		_base_settings.settings.survey_in.acc_limit = survey_in_acc_limit;
+		_base_settings.settings.survey_in.min_dur = survey_in_min_dur;
+	}
+
+	/**
+	 * Set a fixed base station position. This can be used if the base position is already known to
+	 * avoid doing a survey-in.
+	 * @param latitude [deg]
+	 * @param longitude [deg]
+	 * @param altitude [m]
+	 * @param position_accuracy 3D position accuracy (set to 0 if unknown) [mm]
+	 */
+	void setBasePosition(double latitude, double longitude, float altitude, float position_accuracy)
+	{
+		_base_settings.type = BaseSettingsType::fixed_position;
+		_base_settings.settings.fixed_position.latitude = latitude;
+		_base_settings.settings.fixed_position.longitude = longitude;
+		_base_settings.settings.fixed_position.altitude = altitude;
+		_base_settings.settings.fixed_position.position_accuracy = position_accuracy;
+	}
+
+protected:
+
+	enum class BaseSettingsType : uint8_t {
+		survey_in,
+		fixed_position
+	};
+	struct SurveyInSettings {
+		uint32_t acc_limit;
+		uint32_t min_dur;
+	};
+	struct FixedPositionSettings {
+		double latitude;
+		double longitude;
+		float altitude;
+		float position_accuracy;
+	};
+	struct BaseSettings {
+		BaseSettingsType type;
+		union {
+			SurveyInSettings survey_in;
+			FixedPositionSettings fixed_position;
+		} settings;
+	};
+	BaseSettings _base_settings;
+};
+

--- a/src/gps_helper.h
+++ b/src/gps_helper.h
@@ -107,6 +107,9 @@ typedef int (*GPSCallbackPtr)(GPSCallbackType type, void *data1, int data2, void
 
 
 struct SurveyInStatus {
+	double latitude;              /**< NAN if unknown/not set [deg] */
+	double longitude;             /**< NAN if unknown/not set [deg] */
+	float altitude;               /**< NAN if unknown/not set [m] */
 	uint32_t mean_accuracy;       /**< [mm] */
 	uint32_t duration;            /**< [s] */
 	uint8_t flags;                /**< bit 0: valid, bit 1: active */
@@ -153,18 +156,6 @@ public:
 	float getVelocityUpdateRate() { return _rate_vel; }
 	void resetUpdateRates();
 	void storeUpdateRates();
-
-	/**
-	 * set survey-in specs for RTK base station setup (for finding an accurate base station position
-	 * by averaging the position measurements over time).
-	 * @param survey_in_acc_limit minimum accuracy in 0.1mm
-	 * @param survey_in_min_dur minimum duration in seconds
-	 */
-	virtual void setSurveyInSpecs(uint32_t survey_in_acc_limit, uint32_t survey_in_min_dur)
-	{
-		(void)survey_in_acc_limit;
-		(void)survey_in_min_dur;
-	}
 
 protected:
 
@@ -219,6 +210,18 @@ protected:
 	{
 		_callback(GPSCallbackType::setClock, &t, 0, _callback_user);
 	}
+
+	/**
+	 * Convert an ECEF (Earth Centered Earth Fixed) coordinate to LLA WGS84 (Lat, Lon, Alt).
+	 * Ported from: https://stackoverflow.com/a/25428344
+	 * @param ecef_x ECEF X-coordinate [m]
+	 * @param ecef_y ECEF Y-coordinate [m]
+	 * @param ecef_z ECEF Z-coordinate [m]
+	 * @param latitude [deg]
+	 * @param longitude [deg]
+	 * @param altitude [m]
+	 */
+	static void ECEF2lla(double ecef_x, double ecef_y, double ecef_z, double &latitude, double &longitude, float &altitude);
 
 	GPSCallbackPtr _callback{nullptr};
 	void *_callback_user{};

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -40,16 +40,17 @@
  * @author Thomas Gubler <thomasgubler@student.ethz.ch>
  * @author Julian Oes <julian@oes.ch>
  * @author Anton Babushkin <anton.babushkin@me.com>
+ * @author Beat Küng <beat-kueng@gmx.net>
  *
  * @author Hannes Delago
  *   (rework, add ubx7+ compatibility)
  *
  */
 
-#ifndef UBX_H_
-#define UBX_H_
+#pragma once
 
 #include "gps_helper.h"
+#include "base_station.h"
 #include "../../definitions.h"
 
 #define UBX_SYNC1 0xB5
@@ -581,7 +582,7 @@ typedef enum {
 } ubx_ack_state_t;
 
 
-class GPSDriverUBX : public GPSHelper
+class GPSDriverUBX : public GPSBaseStationSupport
 {
 public:
 	GPSDriverUBX(Interface gpsInterface, GPSCallbackPtr callback, void *callback_user,
@@ -594,7 +595,6 @@ public:
 	int receive(unsigned timeout) override;
 	int configure(unsigned &baudrate, OutputMode output_mode) override;
 
-	void setSurveyInSpecs(uint32_t survey_in_acc_limit, uint32_t survey_in_min_dur) override;
 private:
 
 	/**
@@ -664,6 +664,8 @@ private:
 	 */
 	inline bool configureMessageRateAndAck(uint16_t msg, uint8_t rate, bool report_ack_error = false);
 
+	int activateRTCMOutput();
+
 	/**
 	 * Calculate FNV1 hash
 	 */
@@ -693,11 +695,9 @@ private:
 	RTCMParsing	*_rtcm_parsing{nullptr};
 
 	const Interface		_interface;
-	uint32_t _survey_in_acc_limit;
-	uint32_t _survey_in_min_dur;
 
 	// ublox Dynamic platform model default 7: airborne with <2g acceleration
 	uint8_t _dyn_model{7};
 };
 
-#endif /* UBX_H_ */
+


### PR DESCRIPTION
- Avoids the need for survey-in if the position is already known
- The base station position can be read from SurveyInStatus
- Support for both u-Blox & Trimble with a common interface
- Split off a new base class GPSBaseStationSupport that contains the
  base station settings

Tested on both Trimble MB-Two & u-blox M8P.