### PR TITLE
Septentrio & u-blox F9P updates

### DIFF
--- a/src/ashtech.cpp
+++ b/src/ashtech.cpp
@@ -1209,7 +1209,7 @@ void GPSDriverAshtech::activateCorrectionOutput()
 
 		if (len >= 0 && len < (int)sizeof(buffer)) {
 			if (writeAckedCommand(buffer, len, ASH_RESPONSE_TIMEOUT) != 0) {
-				ASH_DEBUG("command %s failed", config_options[conf_i]);
+				ASH_DEBUG("command %s failed", buffer);
 			}
 
 		} else {

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -77,29 +77,27 @@ GPSDriverSBF::configure(unsigned &baudrate, OutputMode output_mode)
 {
 	_configured = false;
 
-	// Check if we're already configured
 	setBaudrate(SBF_TX_CFG_PRT_BAUDRATE);
+	baudrate = SBF_TX_CFG_PRT_BAUDRATE;
 
 	_output_mode = output_mode;
-	baudrate = 115200;
-
-	setBaudrate(baudrate);
-	// Change the baudrate
-	char msg[64];
-	snprintf(msg, sizeof(msg), SBF_CONFIG_BAUDRATE, baudrate);
 
 	if (output_mode != OutputMode::RTCM) {
 		sendMessage(SBF_CONFIG_FORCE_INPUT);
 	}
 
+	// Change the baudrate
+	char msg[64];
+	snprintf(msg, sizeof(msg), SBF_CONFIG_BAUDRATE, baudrate);
+
 	if (!sendMessage(msg)) {
 		return -1; // connection and/or baudrate detection failed
 	}
 
-	if (SBF_TX_CFG_PRT_BAUDRATE != baudrate) {
-		setBaudrate(SBF_TX_CFG_PRT_BAUDRATE);
-		baudrate = SBF_TX_CFG_PRT_BAUDRATE;
-	}
+	/* flush input and wait for at least 50 ms silence */
+	decodeInit();
+	receive(50);
+	decodeInit();
 
 	if (!sendMessageAndWaitForAck(SBF_CONFIG_RESET, SBF_CONFIG_TIMEOUT)) {
 		return -1; // connection and/or baudrate detection failed

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -195,12 +195,13 @@ GPSDriverSBF::sendMessageAndWaitForAck(const char *msg, const int timeout)
 	// For all valid set -, get - and exe -commands, the first line of the reply is an exact copy
 	// of the command as entered by the user, preceded with "$R:"
 	char buf[GPS_READ_BUFFER_SIZE];
-	size_t offset = 0;
+	size_t offset = 1;
 	gps_abstime time_started = gps_absolute_time();
 
 	bool found_response = false;
 
 	do {
+		--offset; //overwrite the null-char
 		int ret = read(reinterpret_cast<uint8_t *>(buf) + offset, sizeof(buf) - offset - 1, timeout);
 
 		if (ret < 0) {
@@ -218,7 +219,7 @@ GPSDriverSBF::sendMessageAndWaitForAck(const char *msg, const int timeout)
 		}
 
 		if (offset >= sizeof(buf)) {
-			offset = 0;
+			offset = 1;
 		}
 
 	} while (time_started + 1000 * timeout > gps_absolute_time());

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -1056,8 +1056,8 @@ GPSDriverUBX::payloadRxInit()
 		break;
 
 	case UBX_MSG_MON_RF:
-		if (_rx_payload_length != sizeof(ubx_payload_rx_mon_rf_t)) {
-			// TODO: there could be more than one block... for now we should be fine with this though
+		if (_rx_payload_length < sizeof(ubx_payload_rx_mon_rf_t) ||
+		    (_rx_payload_length - 4) % sizeof(ubx_payload_rx_mon_rf_t::ubx_payload_rx_mon_rf_block_t) != 0) {
 
 			_rx_state = UBX_RXMSG_ERROR_LENGTH;
 

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -469,7 +469,7 @@ int GPSDriverUBX::configureDevice()
 	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_PVT_I2C, 1, cfg_valset_msg_size);
 	_use_nav_pvt = true;
 	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_DOP_I2C, 1, cfg_valset_msg_size);
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_SVINFO_I2C, (_satellite_info != nullptr) ? 10 : 0, cfg_valset_msg_size);
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_SAT_I2C, (_satellite_info != nullptr) ? 10 : 0, cfg_valset_msg_size);
 	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_MON_RF_I2C, 1, cfg_valset_msg_size);
 
 	if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
@@ -846,6 +846,10 @@ GPSDriverUBX::parseChar(const uint8_t b)
 		addByteToChecksum(b);
 
 		switch (_rx_msg) {
+		case UBX_MSG_NAV_SAT:
+			ret = payloadRxAddNavSat(b);	// add a NAV-SAT payload byte
+			break;
+
 		case UBX_MSG_NAV_SVINFO:
 			ret = payloadRxAddNavSvinfo(b);	// add a NAV-SVINFO payload byte
 			break;
@@ -999,6 +1003,7 @@ GPSDriverUBX::payloadRxInit()
 
 		break;
 
+	case UBX_MSG_NAV_SAT:
 	case UBX_MSG_NAV_SVINFO:
 		if (_satellite_info == nullptr) {
 			_rx_state = UBX_RXMSG_DISABLE;        // disable if sat info not requested
@@ -1145,6 +1150,58 @@ GPSDriverUBX::payloadRxAdd(const uint8_t b)
 	return ret;
 }
 
+int	// -1 = error, 0 = ok, 1 = payload completed
+GPSDriverUBX::payloadRxAddNavSat(const uint8_t b)
+{
+	int ret = 0;
+	uint8_t *p_buf = (uint8_t *)&_buf;
+
+	if (_rx_payload_index < sizeof(ubx_payload_rx_nav_sat_part1_t)) {
+		// Fill Part 1 buffer
+		p_buf[_rx_payload_index] = b;
+
+	} else {
+		if (_rx_payload_index == sizeof(ubx_payload_rx_nav_sat_part1_t)) {
+			// Part 1 complete: decode Part 1 buffer
+			_satellite_info->count = MIN(_buf.payload_rx_nav_sat_part1.numSvs, satellite_info_s::SAT_INFO_MAX_SATELLITES);
+			UBX_TRACE_SVINFO("SAT len %u  numCh %u", (unsigned)_rx_payload_length,
+					 (unsigned)_buf.payload_rx_nav_sat_part1.numSvs);
+		}
+
+		if (_rx_payload_index < sizeof(ubx_payload_rx_nav_sat_part1_t) + _satellite_info->count * sizeof(
+			    ubx_payload_rx_nav_sat_part2_t)) {
+			// Still room in _satellite_info: fill Part 2 buffer
+			unsigned buf_index = (_rx_payload_index - sizeof(ubx_payload_rx_nav_sat_part1_t)) % sizeof(
+						     ubx_payload_rx_nav_sat_part2_t);
+			p_buf[buf_index] = b;
+
+			if (buf_index == sizeof(ubx_payload_rx_nav_sat_part2_t) - 1) {
+				// Part 2 complete: decode Part 2 buffer
+				unsigned sat_index = (_rx_payload_index - sizeof(ubx_payload_rx_nav_sat_part1_t)) / sizeof(
+							     ubx_payload_rx_nav_sat_part2_t);
+				_satellite_info->used[sat_index]	= (uint8_t)(_buf.payload_rx_nav_sat_part2.flags & 0x01);
+				_satellite_info->snr[sat_index]		= (uint8_t)(_buf.payload_rx_nav_sat_part2.cno);
+				_satellite_info->elevation[sat_index]	= (uint8_t)(_buf.payload_rx_nav_sat_part2.elev);
+				_satellite_info->azimuth[sat_index]	= (uint8_t)((float)_buf.payload_rx_nav_sat_part2.azim * 255.0f / 360.0f);
+				_satellite_info->svid[sat_index]	= (uint8_t)(_buf.payload_rx_nav_sat_part2.svId);
+				UBX_TRACE_SVINFO("SAT #%02u  used %u  snr %3u  elevation %3u  azimuth %3u  svid %3u",
+						 (unsigned)sat_index + 1,
+						 (unsigned)_satellite_info->used[sat_index],
+						 (unsigned)_satellite_info->snr[sat_index],
+						 (unsigned)_satellite_info->elevation[sat_index],
+						 (unsigned)_satellite_info->azimuth[sat_index],
+						 (unsigned)_satellite_info->svid[sat_index]
+						);
+			}
+		}
+	}
+
+	if (++_rx_payload_index >= _rx_payload_length) {
+		ret = 1;	// payload received completely
+	}
+
+	return ret;
+}
 /**
  * Add NAV-SVINFO payload rx byte
  */
@@ -1486,6 +1543,7 @@ GPSDriverUBX::payloadRxDone()
 		ret = 1;
 		break;
 
+	case UBX_MSG_NAV_SAT:
 	case UBX_MSG_NAV_SVINFO:
 		UBX_TRACE_RXMSG("Rx NAV-SVINFO");
 

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -273,7 +273,7 @@
 
 #define UBX_CFG_KEY_MSGOUT_UBX_MON_RF_I2C        0x20910359
 #define UBX_CFG_KEY_MSGOUT_UBX_NAV_SVIN_I2C      0x20910088
-#define UBX_CFG_KEY_MSGOUT_UBX_NAV_SVINFO_I2C    0x2091000b
+#define UBX_CFG_KEY_MSGOUT_UBX_NAV_SAT_I2C       0x20910015
 #define UBX_CFG_KEY_MSGOUT_UBX_NAV_DOP_I2C       0x20910038
 #define UBX_CFG_KEY_MSGOUT_UBX_NAV_PVT_I2C       0x20910006
 #define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1005_I2C  0x209102bd
@@ -422,6 +422,25 @@ typedef struct {
 	int16_t		azim; 		/**< Azimuth [deg] */
 	int32_t		prRes; 		/**< Pseudo range residual [cm] */
 } ubx_payload_rx_nav_svinfo_part2_t;
+
+/* Rx NAV-SAT Part 1 */
+typedef struct {
+	uint32_t	iTOW;		/**< GPS Time of Week [ms] */
+	uint8_t		version; 	/**< Message version (1) */
+	uint8_t		numSvs;		/**< Number of Satellites */
+	uint16_t	reserved;
+} ubx_payload_rx_nav_sat_part1_t;
+
+/* Rx NAV-SAT Part 2 (repeated) */
+typedef struct {
+	uint8_t		gnssId;		/**< GNSS identifier */
+	uint8_t		svId; 		/**< Satellite ID */
+	uint8_t		cno;		/**< Carrier to Noise Ratio (Signal Strength) [dbHz] */
+	int8_t		elev; 		/**< Elevation [deg] range: +/-90 */
+	int16_t		azim; 		/**< Azimuth [deg] range: 0-360 */
+	int16_t		prRes; 		/**< Pseudo range residual [0.1 m] */
+	uint32_t	flags;
+} ubx_payload_rx_nav_sat_part2_t;
 
 /* Rx NAV-SVIN (survey-in info) */
 typedef struct {
@@ -665,6 +684,8 @@ typedef union {
 	ubx_payload_rx_nav_timeutc_t		payload_rx_nav_timeutc;
 	ubx_payload_rx_nav_svinfo_part1_t	payload_rx_nav_svinfo_part1;
 	ubx_payload_rx_nav_svinfo_part2_t	payload_rx_nav_svinfo_part2;
+	ubx_payload_rx_nav_sat_part1_t		payload_rx_nav_sat_part1;
+	ubx_payload_rx_nav_sat_part2_t		payload_rx_nav_sat_part2;
 	ubx_payload_rx_nav_svin_t		payload_rx_nav_svin;
 	ubx_payload_rx_nav_velned_t		payload_rx_nav_velned;
 	ubx_payload_rx_mon_hw_ubx6_t		payload_rx_mon_hw_ubx6;
@@ -761,6 +782,7 @@ private:
 	 */
 	int payloadRxAdd(const uint8_t b);
 	int payloadRxAddNavSvinfo(const uint8_t b);
+	int payloadRxAddNavSat(const uint8_t b);
 	int payloadRxAddMonVer(const uint8_t b);
 
 	/**


### PR DESCRIPTION
- 2 fixes for the u-blox F9P:
  - switch from NAV-SVINFO to NAV-SAT (required for protocol 27+)
  - allow multiple MON-RF blocks
- Fixes for septentrio:
  - off-by-one error
  - configuration simplification

Tested against the Sparkfun F9P (https://www.sparkfun.com/products/15136) and the Septentrio AsteRx-m2 UAS (that one only bench-tested).