### PR TITLE
【WIP】 ubx【RTK】:  Add event info for timestamp.

### DIFF
--- a/src/gps_helper.cpp
+++ b/src/gps_helper.cpp
@@ -100,3 +100,23 @@ void GPSHelper::ECEF2lla(double ecef_x, double ecef_y, double ecef_z, double &la
 
 	// correction for altitude near poles left out.
 }
+
+uint64_t
+GPSHelper::gnssTimeToUtc(int week, int usec)
+{
+	// convert from gnss timestamp to unix timestamp
+	uint64_t time_gnss_usec = week * 7 * 24 * 3600 * 1e6 + usec;
+
+	uint64_t time_utc_usec = time_gnss_usec + UTC_TO_GNSS_TIME_INTERVAL * 1e6;
+
+	return time_utc_usec;
+}
+
+uint64_t
+GPSHelper::TimeToUtc(int week, int usec)
+{
+	// convert to unix timestamp
+	uint64_t time_utc_usec = week * 7 * 24 * 3600 * 1e6 + usec;
+
+	return time_utc_usec;
+}

--- a/src/gps_helper.h
+++ b/src/gps_helper.h
@@ -46,6 +46,8 @@
 #define GPS_READ_BUFFER_SIZE 150 ///< buffer size for the read() call. Messages can be longer than that.
 #endif
 
+#define UTC_TO_GNSS_TIME_INTERVAL  315936000      // From UTC to GNSS time interval
+
 enum class GPSCallbackType {
 	/**
 	 * Read data from device. This is a blocking operation with a timeout.
@@ -257,6 +259,9 @@ protected:
 	 * @param altitude [m]
 	 */
 	static void ECEF2lla(double ecef_x, double ecef_y, double ecef_z, double &latitude, double &longitude, float &altitude);
+
+	uint64_t gnssTimeToUtc(int week, int usec);
+	uint64_t timeToUtc(int week, int usec);
 
 	GPSCallbackPtr _callback{nullptr};
 	void *_callback_user{};

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -62,10 +62,12 @@
 #define UBX_CLASS_ACK		0x05
 #define UBX_CLASS_CFG		0x06
 #define UBX_CLASS_MON		0x0A
-#define UBX_CLASS_RTCM3	0xF5
+#define UBX_CLASS_EVENT     0x0D
+#define UBX_CLASS_RTCM3	0xF5 /**< This is undocumented (?) */
 
 /* Message IDs */
 #define UBX_ID_NAV_POSLLH	0x02
+#define UBX_ID_NAV_EVENT    0X03
 #define UBX_ID_NAV_DOP		0x04
 #define UBX_ID_NAV_SOL		0x06
 #define UBX_ID_NAV_PVT		0x07
@@ -154,6 +156,7 @@
 #define UBX_MSG_RTCM3_1127	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1127 << 8)
 #define UBX_MSG_RTCM3_1230	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1230 << 8)
 #define UBX_MSG_RTCM3_4072	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_4072 << 8)
+#define UBX_MSG_TIM_TIM2    ((UBX_CLASS_EVENT) | UBX_ID_NAV_EVENT << 8)
 
 /* RX NAV-PVT message content details */
 /*   Bitfield "valid" masks */
@@ -360,6 +363,19 @@ typedef struct {
 	uint8_t		numSV;		/**< Number of SVs used in Nav Solution */
 	uint32_t	reserved2;
 } ubx_payload_rx_nav_sol_t;
+
+typedef struct {
+	uint8_t ch;      	   /**< Channel (i.e. EXTINT) upon which thepulse was measured */
+	uint8_t flags;         /**< Bitmask */
+	uint16_t count;        /**< rising edge counter */
+	uint16_t wnR;          /**< week number of last rising edge */
+	uint16_t wnF;          /**< week number of last falling edge */
+	uint32_t towMsR;       /**< tow of rising edge (ms)*/
+	uint32_t towSubMsR;    /**< millisecond fraction of tow of rising edgein nanoseconds (ns) */
+	uint32_t towMsF;       /**< tow of falling edge (ms) */
+	uint32_t towSubMsF;    /**< millisecond fraction of tow of falling edgein nanoseconds (ns)*/
+	uint32_t accEst;       /**< Accuracy estimate */
+} ubx_payload_rx_tim_tim2_t;
 
 /* Rx NAV-PVT (ubx8) */
 typedef struct {
@@ -712,6 +728,7 @@ typedef union {
 	ubx_payload_rx_mon_ver_part2_t		payload_rx_mon_ver_part2;
 	ubx_payload_rx_ack_ack_t		payload_rx_ack_ack;
 	ubx_payload_rx_ack_nak_t		payload_rx_ack_nak;
+	ubx_payload_rx_tim_tim2_t       payload_rx_tim_tim2;
 	ubx_payload_tx_cfg_prt_t		payload_tx_cfg_prt;
 	ubx_payload_tx_cfg_rate_t		payload_tx_cfg_rate;
 	ubx_payload_tx_cfg_nav5_t		payload_tx_cfg_nav5;
@@ -764,6 +781,7 @@ public:
 	GPSDriverUBX(Interface gpsInterface, GPSCallbackPtr callback, void *callback_user,
 		     struct vehicle_gps_position_s *gps_position,
 		     struct satellite_info_s *satellite_info,
+			 struct event_info_s *event_info,
 		     uint8_t dynamic_model = 7);
 
 	virtual ~GPSDriverUBX();
@@ -907,6 +925,7 @@ private:
 
 	struct vehicle_gps_position_s *_gps_position {nullptr};
 	struct satellite_info_s *_satellite_info {nullptr};
+	struct event_info_s *_event_info {nullptr};
 	uint64_t		_last_timestamp_time{0};
 	bool			_configured{false};
 	ubx_ack_state_t		_ack_state{UBX_ACK_IDLE};


### PR DESCRIPTION
When we perform 3D modeling of surveying tasks, in order to prevent the delay of the serial port, we need to get the precise time of taking photos.

This is from ubx data sheet：
![picture](https://user-images.githubusercontent.com/23076781/59824558-0b78f580-9364-11e9-97da-4666fa23e53e.png)
