### PR TITLE
ubx: fix baud rate search

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -189,10 +189,6 @@ GPSDriverUBX::configure(unsigned &baudrate, OutputMode output_mode)
 			} else {
 				_proto_ver_27_or_higher = false;
 
-				if (auto_baudrate) {
-					desired_baudrate = UBX_TX_CFG_PRT_BAUDRATE;
-				}
-
 				UBX_DEBUG("trying old protocol");
 
 				/* Send a CFG-PRT message to set the UBX protocol for in and out
@@ -218,6 +214,9 @@ GPSDriverUBX::configure(unsigned &baudrate, OutputMode output_mode)
 					continue;
 				}
 
+				if (auto_baudrate) {
+					desired_baudrate = UBX_TX_CFG_PRT_BAUDRATE;
+				}
 				/* Send a CFG-PRT message again, this time change the baudrate */
 				cfg_prt[0].baudRate	= desired_baudrate;
 				cfg_prt[1].baudRate	= desired_baudrate;


### PR DESCRIPTION
Bug:
In Auto baud rate, if the gps current baud rate is not the first tested,
desired baud rate will be set to the pre 2.7 default bauderate
(UBX_TX_CFG_PRT_BAUDRATE)
For 2.7 and high it should be set to UBX_CFG_KEY_CFG_UART1_BAUDRATE

Solution:
Wait to be sure that protocol version is lower than 2.7 before setting
desired_baudrate to UBX_TX_CFG_PRT_BAUDRATE