### PR TITLE
fixed unused arg compiler warning

### DIFF
--- a/src/gps_helper.h
+++ b/src/gps_helper.h
@@ -185,7 +185,7 @@ public:
 	 *         -1 not implemented
 	 * 	    0 success
 	 */
-	virtual int reset(GPSRestartType restart_type)	{ return -1; }
+	virtual int reset(GPSRestartType restart_type)	{ (void)restart_type; return -1; }
 
 	float getPositionUpdateRate() { return _rate_lat_lon; }
 	float getVelocityUpdateRate() { return _rate_vel; }


### PR DESCRIPTION
This throws a warning, in QGC warnings are errors so QGC master currently does not compile.