### PR TITLE
u-blox: reduce update rate for M9N to 5Hz (instead of 10Hz)

### DIFF
--- a/src/ubx.h
+++ b/src/ubx.h
@@ -902,7 +902,8 @@ private:
 		u_blox6 = 6,
 		u_blox7 = 7,
 		u_blox8 = 8, ///< M8N or M8P
-		u_blox9 = 9, ///< F9P
+		u_blox9 = 9, ///< M9N, or any F9*, except F9P
+		u_blox9_F9P = 10, ///< F9P
 	};
 
 	sensor_gps_s *_gps_position {nullptr};


### PR DESCRIPTION
Apparently a 10Hz update rate restricts the number of used satellites to 16, and as soon as the update rate is reduced, the number of used satellites increases.

The datasheet only mentions that the navigation rate can go up to 25Hz.

Cross-tested on an F9P.