### PR TITLE
Add PRN (SBAS code) to the U-Blox and Ashtech GPS drivers, standardize tab/space formatting within the files, alphabetize ordering

### DIFF
--- a/src/ashtech.cpp
+++ b/src/ashtech.cpp
@@ -52,11 +52,11 @@
 
 GPSDriverAshtech::GPSDriverAshtech(GPSCallbackPtr callback, void *callback_user,
 				   sensor_gps_s *gps_position, satellite_info_s *satellite_info,
-				   float heading_offset)
-	: GPSBaseStationSupport(callback, callback_user)
-	, _heading_offset(heading_offset)
-	, _gps_position(gps_position)
-	, _satellite_info(satellite_info)
+				   float heading_offset) :
+	GPSBaseStationSupport(callback, callback_user),
+	_heading_offset(heading_offset),
+	_gps_position(gps_position),
+	_satellite_info(satellite_info)
 {
 	decodeInit();
 }

--- a/src/ashtech.cpp
+++ b/src/ashtech.cpp
@@ -51,12 +51,12 @@
 #define ASH_DEBUG(...)		{/*GPS_WARN(__VA_ARGS__);*/}
 
 GPSDriverAshtech::GPSDriverAshtech(GPSCallbackPtr callback, void *callback_user,
-				   sensor_gps_s *gps_position,
-				   satellite_info_s *satellite_info, float heading_offset) :
-	GPSBaseStationSupport(callback, callback_user),
-	_satellite_info(satellite_info),
-	_gps_position(gps_position),
-	_heading_offset(heading_offset)
+				   sensor_gps_s *gps_position, satellite_info_s *satellite_info,
+				   float heading_offset)
+	: GPSBaseStationSupport(callback, callback_user)
+	, _heading_offset(heading_offset)
+	, _gps_position(gps_position)
+	, _satellite_info(satellite_info)
 {
 	decodeInit();
 }
@@ -563,7 +563,9 @@ int GPSDriverAshtech::handleMessage(int len)
 			int elevation;
 			int azimuth;
 			int snr;
+			int prn;
 		} sat[4];
+
 		memset(sat, 0, sizeof(sat));
 
 		if (bufptr && *(++bufptr) != ',') { all_msg_num = strtol(bufptr, &endp, 10); bufptr = endp; }
@@ -577,11 +579,12 @@ int GPSDriverAshtech::handleMessage(int len)
 		}
 
 		if (this_msg_num == 0 && bGPS && _satellite_info) {
-			memset(_satellite_info->svid,     0, sizeof(_satellite_info->svid));
-			memset(_satellite_info->used,     0, sizeof(_satellite_info->used));
-			memset(_satellite_info->snr,      0, sizeof(_satellite_info->snr));
+			memset(_satellite_info->svid,      0, sizeof(_satellite_info->svid));
+			memset(_satellite_info->used,      0, sizeof(_satellite_info->used));
 			memset(_satellite_info->elevation, 0, sizeof(_satellite_info->elevation));
-			memset(_satellite_info->azimuth,  0, sizeof(_satellite_info->azimuth));
+			memset(_satellite_info->azimuth,   0, sizeof(_satellite_info->azimuth));
+			memset(_satellite_info->snr,       0, sizeof(_satellite_info->snr));
+			memset(_satellite_info->prn,       0, sizeof(_satellite_info->prn));
 		}
 
 		int end = 4;
@@ -607,11 +610,12 @@ int GPSDriverAshtech::handleMessage(int len)
 
 				if (bufptr && *(++bufptr) != ',') { sat[y].snr = strtol(bufptr, &endp, 10); bufptr = endp; }
 
-				_satellite_info->svid[y + (this_msg_num - 1) * 4]      = sat[y].svid;
-				_satellite_info->used[y + (this_msg_num - 1) * 4]      = (sat[y].snr > 0);
-				_satellite_info->snr[y + (this_msg_num - 1) * 4]       = sat[y].snr;
+				_satellite_info->svid[y      + (this_msg_num - 1) * 4] = sat[y].svid;
+				_satellite_info->used[y      + (this_msg_num - 1) * 4] = (sat[y].snr > 0);
 				_satellite_info->elevation[y + (this_msg_num - 1) * 4] = sat[y].elevation;
-				_satellite_info->azimuth[y + (this_msg_num - 1) * 4]   = sat[y].azimuth;
+				_satellite_info->azimuth[y   + (this_msg_num - 1) * 4] = sat[y].azimuth;
+				_satellite_info->snr[y       + (this_msg_num - 1) * 4] = sat[y].snr;
+				_satellite_info->prn[y       + (this_msg_num - 1) * 4] = sat[y].prn;
 			}
 		}
 

--- a/src/ashtech.cpp
+++ b/src/ashtech.cpp
@@ -417,11 +417,11 @@ int GPSDriverAshtech::handleMessage(int len)
 			lon = -lon;
 		}
 
-		_gps_position->lat = static_cast<int>((int(lat * 0.01) + (lat * 0.01 - int(lat * 0.01)) * 100.0 / 60.0) * 10000000);
-		_gps_position->lon = static_cast<int>((int(lon * 0.01) + (lon * 0.01 - int(lon * 0.01)) * 100.0 / 60.0) * 10000000);
+		_gps_position->lat = static_cast<int>((static_cast<int>(lat * 0.01) + static_cast<int>(lat * 0.01 - int(lat * 0.01)) * 100.0 / 60.0) * 10000000);
+		_gps_position->lon = static_cast<int>((static_cast<int>(lon * 0.01) + static_cast<int>(lon * 0.01 - int(lon * 0.01)) * 100.0 / 60.0) * 10000000);
 		_gps_position->alt = static_cast<int>(alt * 1000);
-		_gps_position->hdop = (float)hdop;
-		_gps_position->vdop = (float)vdop;
+		_gps_position->hdop = static_cast<float>(hdop);
+		_gps_position->vdop = static_cast<float>(vdop);
 		_rate_count_lat_lon++;
 
 		if (coordinatesFound < 3) {
@@ -610,12 +610,12 @@ int GPSDriverAshtech::handleMessage(int len)
 
 				if (bufptr && *(++bufptr) != ',') { sat[y].snr = strtol(bufptr, &endp, 10); bufptr = endp; }
 
-				_satellite_info->svid[y      + (this_msg_num - 1) * 4] = sat[y].svid;
-				_satellite_info->used[y      + (this_msg_num - 1) * 4] = (sat[y].snr > 0);
+				_satellite_info->svid[y + (this_msg_num - 1) * 4]      = sat[y].svid;
+				_satellite_info->used[y + (this_msg_num - 1) * 4]      = (sat[y].snr > 0);
 				_satellite_info->elevation[y + (this_msg_num - 1) * 4] = sat[y].elevation;
-				_satellite_info->azimuth[y   + (this_msg_num - 1) * 4] = sat[y].azimuth;
-				_satellite_info->snr[y       + (this_msg_num - 1) * 4] = sat[y].snr;
-				_satellite_info->prn[y       + (this_msg_num - 1) * 4] = sat[y].prn;
+				_satellite_info->azimuth[y + (this_msg_num - 1) * 4]   = sat[y].azimuth;
+				_satellite_info->snr[y + (this_msg_num - 1) * 4]       = sat[y].snr;
+				_satellite_info->prn[y + (this_msg_num - 1) * 4]       = sat[y].prn;
 			}
 		}
 

--- a/src/ashtech.h
+++ b/src/ashtech.h
@@ -45,8 +45,7 @@
 class RTCMParsing;
 
 #define ASHTECH_RECV_BUFFER_SIZE 512
-
-#define ASH_RESPONSE_TIMEOUT	200		// ms, timeout for waiting for a response
+#define ASH_RESPONSE_TIMEOUT     200    // ms, timeout for waiting for a response
 
 class GPSDriverAshtech : public GPSBaseStationSupport
 {
@@ -56,10 +55,12 @@ public:
 	 */
 	GPSDriverAshtech(GPSCallbackPtr callback, void *callback_user, sensor_gps_s *gps_position,
 			 satellite_info_s *satellite_info, float heading_offset = 0.f);
+
 	virtual ~GPSDriverAshtech();
 
-	int receive(unsigned timeout) override;
 	int configure(unsigned &baudrate, OutputMode output_mode) override;
+
+	int receive(unsigned timeout) override;
 
 private:
 	enum class NMEACommand {
@@ -90,7 +91,9 @@ private:
 	};
 
 	void decodeInit(void);
+
 	int handleMessage(int len);
+
 	int parseChar(uint8_t b);
 
 	/**
@@ -116,18 +119,25 @@ private:
 
 	void activateRTCMOutput();
 
-	satellite_info_s *_satellite_info {nullptr};
+	float _heading_offset;
+
 	sensor_gps_s *_gps_position {nullptr};
+	satellite_info_s *_satellite_info {nullptr};
+
 	uint64_t _last_timestamp_time{0};
 
 	NMEADecodeState _decode_state{NMEADecodeState::uninit};
+
 	uint8_t _rx_buffer[ASHTECH_RECV_BUFFER_SIZE];
 	uint16_t _rx_buffer_bytes{};
+
 	bool _got_pashr_pos_message{false}; /**< If we got a PASHR,POS message, we will ignore GGA messages */
 
 	NMEACommand _waiting_for_command;
 	NMEACommandState _command_state{NMEACommandState::idle};
+
 	char _port{'A'}; /**< port we are connected to (e.g. 'A') */
+
 	AshtechBoard _board{AshtechBoard::other}; /**< board we are connected to */
 
 	RTCMParsing	*_rtcm_parsing{nullptr};
@@ -135,9 +145,9 @@ private:
 	gps_abstime _survey_in_start{0};
 
 	OutputMode _output_mode{OutputMode::GPS};
+
 	bool _correction_output_activated{false};
 	bool _configure_done{false};
 
-	float _heading_offset;
 };
 

--- a/src/ashtech.h
+++ b/src/ashtech.h
@@ -40,6 +40,7 @@
 #include "gps_helper.h"
 #include "base_station.h"
 #include "../../definitions.h"
+
 #include <math.h>
 
 class RTCMParsing;

--- a/src/ashtech.h
+++ b/src/ashtech.h
@@ -63,6 +63,11 @@ public:
 	int receive(unsigned timeout) override;
 
 private:
+	enum class AshtechBoard {
+		trimble_mb_two,
+		other
+	};
+
 	enum class NMEACommand {
 		Acked, // Command that returns a (N)Ack
 		PRT,   // port config
@@ -85,10 +90,12 @@ private:
 		decode_rtcm3
 	};
 
-	enum class AshtechBoard {
-		trimble_mb_two,
-		other
-	};
+	/**
+	 * enable output of correction output
+	 */
+	void activateCorrectionOutput();
+
+	void activateRTCMOutput();
 
 	void decodeInit(void);
 
@@ -97,27 +104,20 @@ private:
 	int parseChar(uint8_t b);
 
 	/**
+	 * receive data for at least the specified amount of time
+	 */
+	void receiveWait(unsigned timeout_min);
+
+	void sendSurveyInStatusUpdate(bool active, bool valid, double latitude = static_cast<double>(NAN),
+				      double longitude = static_cast<double>(NAN), float altitude = NAN);
+
+	/**
 	 * Write a command and wait for a (N)Ack
 	 * @return 0 on success, <0 otherwise
 	 */
 	int writeAckedCommand(const void *buf, int buf_length, unsigned timeout);
 
 	int waitForReply(NMEACommand command, const unsigned timeout);
-
-	/**
-	 * receive data for at least the specified amount of time
-	 */
-	void receiveWait(unsigned timeout_min);
-
-	/**
-	 * enable output of correction output
-	 */
-	void activateCorrectionOutput();
-
-	void sendSurveyInStatusUpdate(bool active, bool valid, double latitude = (double)NAN, double longitude = (double)NAN,
-				      float altitude = NAN);
-
-	void activateRTCMOutput();
 
 	bool _correction_output_activated{false};
 	bool _configure_done{false};

--- a/src/ashtech.h
+++ b/src/ashtech.h
@@ -119,35 +119,34 @@ private:
 
 	void activateRTCMOutput();
 
-	float _heading_offset;
-
-	sensor_gps_s *_gps_position {nullptr};
-	satellite_info_s *_satellite_info {nullptr};
-
-	uint64_t _last_timestamp_time{0};
-
-	NMEADecodeState _decode_state{NMEADecodeState::uninit};
-
-	uint8_t _rx_buffer[ASHTECH_RECV_BUFFER_SIZE];
-	uint16_t _rx_buffer_bytes{};
-
+	bool _correction_output_activated{false};
+	bool _configure_done{false};
 	bool _got_pashr_pos_message{false}; /**< If we got a PASHR,POS message, we will ignore GGA messages */
-
-	NMEACommand _waiting_for_command;
-	NMEACommandState _command_state{NMEACommandState::idle};
 
 	char _port{'A'}; /**< port we are connected to (e.g. 'A') */
 
-	AshtechBoard _board{AshtechBoard::other}; /**< board we are connected to */
+	uint8_t _rx_buffer[ASHTECH_RECV_BUFFER_SIZE];
+	uint16_t _rx_buffer_bytes{};
+	uint64_t _last_timestamp_time{0};
 
-	RTCMParsing	*_rtcm_parsing{nullptr};
+	float _heading_offset;
 
 	gps_abstime _survey_in_start{0};
 
+	sensor_gps_s* _gps_position {nullptr};
+
+	satellite_info_s* _satellite_info {nullptr};
+
+	AshtechBoard _board{AshtechBoard::other}; /**< board we are connected to */
+
+	NMEACommand _waiting_for_command;
+
+	NMEACommandState _command_state{NMEACommandState::idle};
+
+	NMEADecodeState _decode_state{NMEADecodeState::uninit};
+
 	OutputMode _output_mode{OutputMode::GPS};
 
-	bool _correction_output_activated{false};
-	bool _configure_done{false};
-
+	RTCMParsing* _rtcm_parsing{nullptr};
 };
 

--- a/src/femtomes.cpp
+++ b/src/femtomes.cpp
@@ -67,10 +67,10 @@
 
 GPSDriverFemto::GPSDriverFemto(GPSCallbackPtr callback, void *callback_user,
 			       struct sensor_gps_s *gps_position,
-			       float heading_offset)
-	: GPSHelper(callback, callback_user)
-	, _gps_position(gps_position)
-	, _heading_offset(heading_offset)
+			       float heading_offset) :
+	GPSHelper(callback, callback_user),
+	_gps_position(gps_position),
+	_heading_offset(heading_offset)
 {
 	decodeInit();
 }

--- a/src/gps_helper.cpp
+++ b/src/gps_helper.cpp
@@ -46,8 +46,9 @@
  * @author Julian Oes <julian@oes.ch>
  */
 
-GPSHelper::GPSHelper(GPSCallbackPtr callback, void *callback_user)
-	: _callback(callback), _callback_user(callback_user)
+GPSHelper::GPSHelper(GPSCallbackPtr callback, void *callback_user) :
+	_callback(callback),
+	_callback_user(callback_user)
 {
 }
 

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -59,11 +59,11 @@
 GPSDriverSBF::GPSDriverSBF(GPSCallbackPtr callback, void *callback_user,
 			   sensor_gps_s *gps_position,
 			   satellite_info_s *satellite_info,
-			   uint8_t dynamic_model)
-	: GPSBaseStationSupport(callback, callback_user)
-	, _gps_position(gps_position)
-	, _satellite_info(satellite_info)
-	, _dynamic_model(dynamic_model)
+			   uint8_t dynamic_model) :
+	GPSBaseStationSupport(callback, callback_user),
+	_gps_position(gps_position),
+	_satellite_info(satellite_info),
+	_dynamic_model(dynamic_model)
 {
 	decodeInit();
 }

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -286,7 +286,7 @@ GPSDriverUBX::configure(unsigned &baudrate, OutputMode output_mode)
 		return -1;
 	}
 
-	UBX_DEBUG("Protocol version 27+: %i", (int)_proto_ver_27_or_higher);
+	UBX_DEBUG("Protocol version 27+: %i", static_cast<int>(_proto_ver_27_or_higher));
 
 	/* Request module version information by sending an empty MON-VER message */
 	if (!sendMessage(UBX_MSG_MON_VER, nullptr, 0)) {
@@ -910,7 +910,7 @@ GPSDriverUBX::parseChar(const uint8_t b)
 
 	case UBX_DECODE_RTCM3:
 		if (_rtcm_parsing->addByte(b)) {
-			UBX_DEBUG("got RTCM message with length %i", (int)_rtcm_parsing->messageLength());
+			UBX_DEBUG("got RTCM message with length %i", static_cast<int>(_rtcm_parsing->messageLength()));
 			gotRTCMMessage(_rtcm_parsing->message(), _rtcm_parsing->messageLength());
 			decodeInit();
 		}
@@ -1317,7 +1317,7 @@ GPSDriverUBX::payloadRxAddMonVer(const uint8_t b)
 				UBX_WARN("unknown board hw: %s", _buf.payload_rx_mon_ver_part1.hwVersion);
 			}
 
-			UBX_DEBUG("detected board: %i", (int)_board);
+			UBX_DEBUG("detected board: %i", static_cast<int>(_board));
 		}
 
 		// fill Part 2 buffer
@@ -1397,18 +1397,18 @@ GPSDriverUBX::payloadRxDone()
 		_gps_position->alt		= _buf.payload_rx_nav_pvt.hMSL;
 		_gps_position->alt_ellipsoid	= _buf.payload_rx_nav_pvt.height;
 
-		_gps_position->eph		= (float)_buf.payload_rx_nav_pvt.hAcc * 1e-3f;
-		_gps_position->epv		= (float)_buf.payload_rx_nav_pvt.vAcc * 1e-3f;
-		_gps_position->s_variance_m_s	= (float)_buf.payload_rx_nav_pvt.sAcc * 1e-3f;
+		_gps_position->eph		= static_cast<float>(_buf.payload_rx_nav_pvt.hAcc) * 1e-3f;
+		_gps_position->epv		= static_cast<float>(_buf.payload_rx_nav_pvt.vAcc) * 1e-3f;
+		_gps_position->s_variance_m_s	= static_cast<float>(_buf.payload_rx_nav_pvt.sAcc) * 1e-3f;
 
-		_gps_position->vel_m_s		= (float)_buf.payload_rx_nav_pvt.gSpeed * 1e-3f;
+		_gps_position->vel_m_s		= static_cast<float>(_buf.payload_rx_nav_pvt.gSpeed) * 1e-3f;
 
-		_gps_position->vel_n_m_s	= (float)_buf.payload_rx_nav_pvt.velN * 1e-3f;
-		_gps_position->vel_e_m_s	= (float)_buf.payload_rx_nav_pvt.velE * 1e-3f;
-		_gps_position->vel_d_m_s	= (float)_buf.payload_rx_nav_pvt.velD * 1e-3f;
+		_gps_position->vel_n_m_s	= static_cast<float>(_buf.payload_rx_nav_pvt.velN) * 1e-3f;
+		_gps_position->vel_e_m_s	= static_cast<float>(_buf.payload_rx_nav_pvt.velE) * 1e-3f;
+		_gps_position->vel_d_m_s	= static_cast<float>(_buf.payload_rx_nav_pvt.velD) * 1e-3f;
 
-		_gps_position->cog_rad		= (float)_buf.payload_rx_nav_pvt.headMot * M_DEG_TO_RAD_F * 1e-5f;
-		_gps_position->c_variance_rad	= (float)_buf.payload_rx_nav_pvt.headAcc * M_DEG_TO_RAD_F * 1e-5f;
+		_gps_position->cog_rad		= static_cast<float>(_buf.payload_rx_nav_pvt.headMot) * M_DEG_TO_RAD_F * 1e-5f;
+		_gps_position->c_variance_rad	= static_cast<float>(_buf.payload_rx_nav_pvt.headAcc) * M_DEG_TO_RAD_F * 1e-5f;
 
 		//Check if time and date fix flags are good
 		if ((_buf.payload_rx_nav_pvt.valid & UBX_RX_NAV_PVT_VALID_VALIDDATE)
@@ -1483,8 +1483,8 @@ GPSDriverUBX::payloadRxDone()
 		_gps_position->lat	= _buf.payload_rx_nav_posllh.lat;
 		_gps_position->lon	= _buf.payload_rx_nav_posllh.lon;
 		_gps_position->alt	= _buf.payload_rx_nav_posllh.hMSL;
-		_gps_position->eph	= (float)_buf.payload_rx_nav_posllh.hAcc * 1e-3f; // from mm to m
-		_gps_position->epv	= (float)_buf.payload_rx_nav_posllh.vAcc * 1e-3f; // from mm to m
+		_gps_position->eph	= static_cast<float>(_buf.payload_rx_nav_posllh.hAcc) * 1e-3f; // from mm to m
+		_gps_position->epv	= static_cast<float>(_buf.payload_rx_nav_posllh.vAcc) * 1e-3f; // from mm to m
 		_gps_position->alt_ellipsoid = _buf.payload_rx_nav_posllh.height;
 
 		_gps_position->timestamp = gps_absolute_time();
@@ -1499,7 +1499,7 @@ GPSDriverUBX::payloadRxDone()
 		UBX_TRACE_RXMSG("Rx NAV-SOL");
 
 		_gps_position->fix_type		= _buf.payload_rx_nav_sol.gpsFix;
-		_gps_position->s_variance_m_s	= (float)_buf.payload_rx_nav_sol.sAcc * 1e-2f;	// from cm to m
+		_gps_position->s_variance_m_s	= static_cast<float>(_buf.payload_rx_nav_sol.sAcc) * 1e-2f;	// from cm to m
 		_gps_position->satellites_used	= _buf.payload_rx_nav_sol.numSV;
 
 		ret = 1;
@@ -1576,7 +1576,7 @@ GPSDriverUBX::payloadRxDone()
 			ubx_payload_rx_nav_svin_t &svin = _buf.payload_rx_nav_svin;
 
 			UBX_DEBUG("Survey-in status: %is cur accuracy: %imm nr obs: %i valid: %i active: %i",
-				  svin.dur, svin.meanAcc / 10, svin.obs, (int)svin.valid, (int)svin.active);
+				  svin.dur, svin.meanAcc / 10, svin.obs, static_cast<int>(svin.valid), static_cast<int>(svin.active));
 
 			SurveyInStatus status{};
 			double ecef_x = (static_cast<double>(svin.meanX) + static_cast<double>(svin.meanXHP) * 0.01) * 0.01;

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -52,7 +52,6 @@
 
 #include <string.h>
 
-#include "base_station.h"
 #include "rtcm.h"
 #include "ubx.h"
 

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -423,15 +423,18 @@ typedef struct {
 
 /* Rx NAV-SVINFO Part 2 (repeated) */
 typedef struct {
-	uint8_t		chn; 		/**< Channel number, 255 for SVs not assigned to a channel */
-	uint8_t		svid; 		/**< Satellite ID */
+	uint8_t		chn;            /**< Channel number, 255 for SVs not assigned to a channel */
+	uint8_t		svid;           /**< Satellite ID */
 	uint8_t		flags;
 	uint8_t		quality;
-	uint8_t		cno;		/**< Carrier to Noise Ratio (Signal Strength) [dbHz] */
-	int8_t		elev; 		/**< Elevation [deg] */
-	int16_t		azim; 		/**< Azimuth [deg] */
-	int32_t		prRes; 		/**< Pseudo range residual [cm] */
+	int8_t		elev;           /**< Elevation [deg] */
+	int16_t		azim;           /**< Azimuth [deg] */
+	uint8_t		cno;            /**< Carrier to Noise Ratio (Signal Strength) [dbHz] */
+	uint8_t		snr;            /**< Signal to Noise Ratio */
+	uint8_t		prn;            /**< Psuedo Random Number SBAS code, [120-144] */
+	int32_t		prRes;          /**< Pseudo range residual [cm] */
 } ubx_payload_rx_nav_svinfo_part2_t;
+
 
 /* Rx NAV-SAT Part 1 */
 typedef struct {
@@ -443,12 +446,13 @@ typedef struct {
 
 /* Rx NAV-SAT Part 2 (repeated) */
 typedef struct {
-	uint8_t		gnssId;		/**< GNSS identifier */
-	uint8_t		svId; 		/**< Satellite ID */
-	uint8_t		cno;		/**< Carrier to Noise Ratio (Signal Strength) [dbHz] */
-	int8_t		elev; 		/**< Elevation [deg] range: +/-90 */
-	int16_t		azim; 		/**< Azimuth [deg] range: 0-360 */
-	int16_t		prRes; 		/**< Pseudo range residual [0.1 m] */
+	uint8_t		gnssId;         /**< GNSS identifier */
+	uint8_t		svId;           /**< Satellite ID */
+	int8_t		elev;           /**< Elevation [deg] range: +/-90 */
+	int16_t		azim;           /**< Azimuth [deg] range: 0-360 */
+	uint8_t		cno;            /**< Carrier to Noise Ratio (Signal Strength) [dbHz] */
+	uint8_t		prn;            /**< Psuedo Random Number SBAS code, [120-144] */
+	int16_t		prRes;          /**< Pseudo range residual [0.1 m] */
 	uint32_t	flags;
 } ubx_payload_rx_nav_sat_part2_t;
 
@@ -762,8 +766,7 @@ class GPSDriverUBX : public GPSBaseStationSupport
 {
 public:
 	GPSDriverUBX(Interface gpsInterface, GPSCallbackPtr callback, void *callback_user,
-		     sensor_gps_s *gps_position,
-		     satellite_info_s *satellite_info,
+		     sensor_gps_s *gps_position, satellite_info_s *satellite_info,
 		     uint8_t dynamic_model = 7);
 
 	virtual ~GPSDriverUBX();
@@ -906,6 +909,8 @@ private:
 		u_blox9_F9P = 10, ///< F9P
 	};
 
+	const Interface		_interface;
+
 	sensor_gps_s *_gps_position {nullptr};
 	satellite_info_s *_satellite_info {nullptr};
 	uint64_t		_last_timestamp_time{0};
@@ -930,7 +935,6 @@ private:
 
 	RTCMParsing	*_rtcm_parsing{nullptr};
 
-	const Interface		_interface;
 	Board			_board{Board::unknown};
 
 	// ublox Dynamic platform model default 7: airborne with <2g acceleration

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -53,250 +53,257 @@
 #include "base_station.h"
 #include "../../definitions.h"
 
-#define UBX_SYNC1 0xB5
-#define UBX_SYNC2 0x62
+#define UBX_SYNC1             0xB5
+#define UBX_SYNC2             0x62
 
 /* Message Classes */
-#define UBX_CLASS_NAV		0x01
-#define UBX_CLASS_INF		0x04
-#define UBX_CLASS_ACK		0x05
-#define UBX_CLASS_CFG		0x06
-#define UBX_CLASS_MON		0x0A
-#define UBX_CLASS_RTCM3	0xF5
+#define UBX_CLASS_NAV         0x01
+#define UBX_CLASS_INF         0x04
+#define UBX_CLASS_ACK         0x05
+#define UBX_CLASS_CFG         0x06
+#define UBX_CLASS_MON         0x0A
+#define UBX_CLASS_RTCM3       0xF5
 
 /* Message IDs */
-#define UBX_ID_NAV_POSLLH	0x02
-#define UBX_ID_NAV_DOP		0x04
-#define UBX_ID_NAV_SOL		0x06
-#define UBX_ID_NAV_PVT		0x07
-#define UBX_ID_NAV_VELNED	0x12
-#define UBX_ID_NAV_TIMEUTC	0x21
-#define UBX_ID_NAV_SVINFO	0x30
-#define UBX_ID_NAV_SAT		0x35
-#define UBX_ID_NAV_SVIN  	0x3B
-#define UBX_ID_NAV_RELPOSNED  	0x3C
-#define UBX_ID_INF_DEBUG  	0x04
-#define UBX_ID_INF_ERROR  	0x00
-#define UBX_ID_INF_NOTICE  	0x02
-#define UBX_ID_INF_WARNING 	0x01
-#define UBX_ID_ACK_NAK		0x00
-#define UBX_ID_ACK_ACK		0x01
-#define UBX_ID_CFG_PRT		0x00 // deprecated in protocol version >= 27 -> use CFG_VALSET
-#define UBX_ID_CFG_MSG		0x01 // deprecated in protocol version >= 27 -> use CFG_VALSET
-#define UBX_ID_CFG_RATE	0x08 // deprecated in protocol version >= 27 -> use CFG_VALSET
-#define UBX_ID_CFG_CFG		0x09 // deprecated in protocol version >= 27 -> use CFG_VALSET
-#define UBX_ID_CFG_NAV5	0x24 // deprecated in protocol version >= 27 -> use CFG_VALSET
-#define UBX_ID_CFG_RST	0x04
-#define UBX_ID_CFG_SBAS	0x16
-#define UBX_ID_CFG_TMODE3	0x71 // deprecated in protocol version >= 27 -> use CFG_VALSET
-#define UBX_ID_CFG_VALSET	0x8A
-#define UBX_ID_CFG_VALGET	0x8B
-#define UBX_ID_CFG_VALDEL	0x8C
-#define UBX_ID_MON_VER		0x04
-#define UBX_ID_MON_HW		0x09 // deprecated in protocol version >= 27 -> use MON_RF
-#define UBX_ID_MON_RF		0x38
+#define UBX_ID_NAV_POSLLH     0x02
+#define UBX_ID_NAV_DOP        0x04
+#define UBX_ID_NAV_SOL        0x06
+#define UBX_ID_NAV_PVT        0x07
+#define UBX_ID_NAV_VELNED     0x12
+#define UBX_ID_NAV_TIMEUTC    0x21
+#define UBX_ID_NAV_SVINFO     0x30
+#define UBX_ID_NAV_SAT        0x35
+#define UBX_ID_NAV_SVIN       0x3B
+#define UBX_ID_NAV_RELPOSNED  0x3C
+#define UBX_ID_INF_DEBUG      0x04
+#define UBX_ID_INF_ERROR      0x00
+#define UBX_ID_INF_NOTICE     0x02
+#define UBX_ID_INF_WARNING    0x01
+#define UBX_ID_ACK_NAK        0x00
+#define UBX_ID_ACK_ACK        0x01
+#define UBX_ID_CFG_PRT        0x00 // deprecated in protocol version >= 27 -> use CFG_VALSET
+#define UBX_ID_CFG_MSG        0x01 // deprecated in protocol version >= 27 -> use CFG_VALSET
+#define UBX_ID_CFG_RATE       0x08 // deprecated in protocol version >= 27 -> use CFG_VALSET
+#define UBX_ID_CFG_CFG        0x09 // deprecated in protocol version >= 27 -> use CFG_VALSET
+#define UBX_ID_CFG_NAV5       0x24 // deprecated in protocol version >= 27 -> use CFG_VALSET
+#define UBX_ID_CFG_RST        0x04
+#define UBX_ID_CFG_SBAS       0x16
+#define UBX_ID_CFG_TMODE3     0x71 // deprecated in protocol version >= 27 -> use CFG_VALSET
+#define UBX_ID_CFG_VALSET     0x8A
+#define UBX_ID_CFG_VALGET     0x8B
+#define UBX_ID_CFG_VALDEL     0x8C
+#define UBX_ID_MON_VER        0x04
+#define UBX_ID_MON_HW         0x09 // deprecated in protocol version >= 27 -> use MON_RF
+#define UBX_ID_MON_RF         0x38
 
 /* UBX ID for RTCM3 output messages */
 /* Minimal messages for RTK: 1005, 1077 + (1087 or 1127) */
 /* Reduced message size using MSM4: 1005, 1074 + (1084 or 1124)  */
-#define UBX_ID_RTCM3_1005	0x05	/**< Stationary RTK reference station ARP */
-#define UBX_ID_RTCM3_1074	0x4A	/**< GPS MSM4 */
-#define UBX_ID_RTCM3_1077	0x4D	/**< GPS MSM7 */
-#define UBX_ID_RTCM3_1084	0x54	/**< GLONASS MSM4 */
-#define UBX_ID_RTCM3_1087	0x57	/**< GLONASS MSM7 */
-#define UBX_ID_RTCM3_1094	0x5E	/**< Galileo MSM4 */
-#define UBX_ID_RTCM3_1097	0x61	/**< Galileo MSM7 */
-#define UBX_ID_RTCM3_1124	0x7C	/**< BeiDou MSM4 */
-#define UBX_ID_RTCM3_1127	0x7F	/**< BeiDou MSM7 */
-#define UBX_ID_RTCM3_1230	0xE6	/**< GLONASS code-phase biases */
-#define UBX_ID_RTCM3_4072	0xFE	/**< Reference station PVT (u-blox proprietary RTCM Message) - Used for moving baseline */
+#define UBX_ID_RTCM3_1005     0x05    /**< Stationary RTK reference station ARP */
+#define UBX_ID_RTCM3_1074     0x4A    /**< GPS MSM4 */
+#define UBX_ID_RTCM3_1077     0x4D    /**< GPS MSM7 */
+#define UBX_ID_RTCM3_1084     0x54    /**< GLONASS MSM4 */
+#define UBX_ID_RTCM3_1087     0x57    /**< GLONASS MSM7 */
+#define UBX_ID_RTCM3_1094     0x5E    /**< Galileo MSM4 */
+#define UBX_ID_RTCM3_1097     0x61    /**< Galileo MSM7 */
+#define UBX_ID_RTCM3_1124     0x7C    /**< BeiDou MSM4 */
+#define UBX_ID_RTCM3_1127     0x7F    /**< BeiDou MSM7 */
+#define UBX_ID_RTCM3_1230     0xE6    /**< GLONASS code-phase biases */
+#define UBX_ID_RTCM3_4072     0xFE    /**< Reference station PVT (u-blox proprietary RTCM Message) - Used for moving baseline */
 
 
 /* Message Classes & IDs */
-#define UBX_MSG_NAV_POSLLH	((UBX_CLASS_NAV) | UBX_ID_NAV_POSLLH << 8)
-#define UBX_MSG_NAV_SOL		((UBX_CLASS_NAV) | UBX_ID_NAV_SOL << 8)
-#define UBX_MSG_NAV_DOP		((UBX_CLASS_NAV) | UBX_ID_NAV_DOP << 8)
-#define UBX_MSG_NAV_PVT		((UBX_CLASS_NAV) | UBX_ID_NAV_PVT << 8)
-#define UBX_MSG_NAV_VELNED	((UBX_CLASS_NAV) | UBX_ID_NAV_VELNED << 8)
-#define UBX_MSG_NAV_TIMEUTC	((UBX_CLASS_NAV) | UBX_ID_NAV_TIMEUTC << 8)
-#define UBX_MSG_NAV_SVINFO	((UBX_CLASS_NAV) | UBX_ID_NAV_SVINFO << 8)
-#define UBX_MSG_NAV_SAT	((UBX_CLASS_NAV) | UBX_ID_NAV_SAT << 8)
-#define UBX_MSG_NAV_SVIN	((UBX_CLASS_NAV) | UBX_ID_NAV_SVIN << 8)
-#define UBX_MSG_NAV_RELPOSNED	((UBX_CLASS_NAV) | UBX_ID_NAV_RELPOSNED << 8)
-#define UBX_MSG_INF_DEBUG	((UBX_CLASS_INF) | UBX_ID_INF_DEBUG << 8)
-#define UBX_MSG_INF_ERROR	((UBX_CLASS_INF) | UBX_ID_INF_ERROR << 8)
-#define UBX_MSG_INF_NOTICE	((UBX_CLASS_INF) | UBX_ID_INF_NOTICE << 8)
-#define UBX_MSG_INF_WARNING	((UBX_CLASS_INF) | UBX_ID_INF_WARNING << 8)
-#define UBX_MSG_ACK_NAK		((UBX_CLASS_ACK) | UBX_ID_ACK_NAK << 8)
-#define UBX_MSG_ACK_ACK		((UBX_CLASS_ACK) | UBX_ID_ACK_ACK << 8)
-#define UBX_MSG_CFG_PRT		((UBX_CLASS_CFG) | UBX_ID_CFG_PRT << 8)
-#define UBX_MSG_CFG_MSG		((UBX_CLASS_CFG) | UBX_ID_CFG_MSG << 8)
-#define UBX_MSG_CFG_RATE	((UBX_CLASS_CFG) | UBX_ID_CFG_RATE << 8)
-#define UBX_MSG_CFG_CFG		((UBX_CLASS_CFG) | UBX_ID_CFG_CFG << 8)
-#define UBX_MSG_CFG_NAV5	((UBX_CLASS_CFG) | UBX_ID_CFG_NAV5 << 8)
-#define UBX_MSG_CFG_RST 	((UBX_CLASS_CFG) | UBX_ID_CFG_RST << 8)
-#define UBX_MSG_CFG_SBAS	((UBX_CLASS_CFG) | UBX_ID_CFG_SBAS << 8)
-#define UBX_MSG_CFG_TMODE3	((UBX_CLASS_CFG) | UBX_ID_CFG_TMODE3 << 8)
-#define UBX_MSG_CFG_VALGET	((UBX_CLASS_CFG) | UBX_ID_CFG_VALGET << 8)
-#define UBX_MSG_CFG_VALSET	((UBX_CLASS_CFG) | UBX_ID_CFG_VALSET << 8)
-#define UBX_MSG_CFG_VALDEL	((UBX_CLASS_CFG) | UBX_ID_CFG_VALDEL << 8)
-#define UBX_MSG_MON_HW		((UBX_CLASS_MON) | UBX_ID_MON_HW << 8)
-#define UBX_MSG_MON_VER		((UBX_CLASS_MON) | UBX_ID_MON_VER << 8)
-#define UBX_MSG_MON_RF		((UBX_CLASS_MON) | UBX_ID_MON_RF << 8)
-#define UBX_MSG_RTCM3_1005	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1005 << 8)
-#define UBX_MSG_RTCM3_1077	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1077 << 8)
-#define UBX_MSG_RTCM3_1087	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1087 << 8)
-#define UBX_MSG_RTCM3_1074	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1074 << 8)
-#define UBX_MSG_RTCM3_1084	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1084 << 8)
-#define UBX_MSG_RTCM3_1094	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1094 << 8)
-#define UBX_MSG_RTCM3_1097	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1097 << 8)
-#define UBX_MSG_RTCM3_1124	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1124 << 8)
-#define UBX_MSG_RTCM3_1127	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1127 << 8)
-#define UBX_MSG_RTCM3_1230	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1230 << 8)
-#define UBX_MSG_RTCM3_4072	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_4072 << 8)
+#define UBX_MSG_NAV_POSLLH    ((UBX_CLASS_NAV) | UBX_ID_NAV_POSLLH << 8)
+#define UBX_MSG_NAV_SOL       ((UBX_CLASS_NAV) | UBX_ID_NAV_SOL << 8)
+#define UBX_MSG_NAV_DOP       ((UBX_CLASS_NAV) | UBX_ID_NAV_DOP << 8)
+#define UBX_MSG_NAV_PVT       ((UBX_CLASS_NAV) | UBX_ID_NAV_PVT << 8)
+#define UBX_MSG_NAV_VELNED    ((UBX_CLASS_NAV) | UBX_ID_NAV_VELNED << 8)
+#define UBX_MSG_NAV_TIMEUTC   ((UBX_CLASS_NAV) | UBX_ID_NAV_TIMEUTC << 8)
+#define UBX_MSG_NAV_SVINFO    ((UBX_CLASS_NAV) | UBX_ID_NAV_SVINFO << 8)
+#define UBX_MSG_NAV_SAT       ((UBX_CLASS_NAV) | UBX_ID_NAV_SAT << 8)
+#define UBX_MSG_NAV_SVIN      ((UBX_CLASS_NAV) | UBX_ID_NAV_SVIN << 8)
+#define UBX_MSG_NAV_RELPOSNED ((UBX_CLASS_NAV) | UBX_ID_NAV_RELPOSNED << 8)
+#define UBX_MSG_INF_DEBUG     ((UBX_CLASS_INF) | UBX_ID_INF_DEBUG << 8)
+#define UBX_MSG_INF_ERROR     ((UBX_CLASS_INF) | UBX_ID_INF_ERROR << 8)
+#define UBX_MSG_INF_NOTICE    ((UBX_CLASS_INF) | UBX_ID_INF_NOTICE << 8)
+#define UBX_MSG_INF_WARNING   ((UBX_CLASS_INF) | UBX_ID_INF_WARNING << 8)
+#define UBX_MSG_ACK_NAK       ((UBX_CLASS_ACK) | UBX_ID_ACK_NAK << 8)
+#define UBX_MSG_ACK_ACK       ((UBX_CLASS_ACK) | UBX_ID_ACK_ACK << 8)
+#define UBX_MSG_CFG_PRT       ((UBX_CLASS_CFG) | UBX_ID_CFG_PRT << 8)
+#define UBX_MSG_CFG_MSG       ((UBX_CLASS_CFG) | UBX_ID_CFG_MSG << 8)
+#define UBX_MSG_CFG_RATE      ((UBX_CLASS_CFG) | UBX_ID_CFG_RATE << 8)
+#define UBX_MSG_CFG_CFG       ((UBX_CLASS_CFG) | UBX_ID_CFG_CFG << 8)
+#define UBX_MSG_CFG_NAV5      ((UBX_CLASS_CFG) | UBX_ID_CFG_NAV5 << 8)
+#define UBX_MSG_CFG_RST       ((UBX_CLASS_CFG) | UBX_ID_CFG_RST << 8)
+#define UBX_MSG_CFG_SBAS      ((UBX_CLASS_CFG) | UBX_ID_CFG_SBAS << 8)
+#define UBX_MSG_CFG_TMODE3    ((UBX_CLASS_CFG) | UBX_ID_CFG_TMODE3 << 8)
+#define UBX_MSG_CFG_VALGET    ((UBX_CLASS_CFG) | UBX_ID_CFG_VALGET << 8)
+#define UBX_MSG_CFG_VALSET    ((UBX_CLASS_CFG) | UBX_ID_CFG_VALSET << 8)
+#define UBX_MSG_CFG_VALDEL    ((UBX_CLASS_CFG) | UBX_ID_CFG_VALDEL << 8)
+#define UBX_MSG_MON_HW        ((UBX_CLASS_MON) | UBX_ID_MON_HW << 8)
+#define UBX_MSG_MON_VER       ((UBX_CLASS_MON) | UBX_ID_MON_VER << 8)
+#define UBX_MSG_MON_RF        ((UBX_CLASS_MON) | UBX_ID_MON_RF << 8)
+#define UBX_MSG_RTCM3_1005    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1005 << 8)
+#define UBX_MSG_RTCM3_1077    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1077 << 8)
+#define UBX_MSG_RTCM3_1087    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1087 << 8)
+#define UBX_MSG_RTCM3_1074    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1074 << 8)
+#define UBX_MSG_RTCM3_1084    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1084 << 8)
+#define UBX_MSG_RTCM3_1094    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1094 << 8)
+#define UBX_MSG_RTCM3_1097    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1097 << 8)
+#define UBX_MSG_RTCM3_1124    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1124 << 8)
+#define UBX_MSG_RTCM3_1127    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1127 << 8)
+#define UBX_MSG_RTCM3_1230    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1230 << 8)
+#define UBX_MSG_RTCM3_4072    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_4072 << 8)
 
 /* RX NAV-PVT message content details */
 /*   Bitfield "valid" masks */
-#define UBX_RX_NAV_PVT_VALID_VALIDDATE		0x01	/**< validDate (Valid UTC Date) */
-#define UBX_RX_NAV_PVT_VALID_VALIDTIME		0x02	/**< validTime (Valid UTC Time) */
-#define UBX_RX_NAV_PVT_VALID_FULLYRESOLVED	0x04	/**< fullyResolved (1 = UTC Time of Day has been fully resolved (no seconds uncertainty)) */
+#define UBX_RX_NAV_PVT_VALID_VALIDDATE          0x01    /**< validDate (Valid UTC Date) */
+#define UBX_RX_NAV_PVT_VALID_VALIDTIME          0x02    /**< validTime (Valid UTC Time) */
+#define UBX_RX_NAV_PVT_VALID_FULLYRESOLVED      0x04    /**< fullyResolved (1 = UTC Time of Day has been fully resolved (no seconds uncertainty)) */
 
 /*   Bitfield "flags" masks */
-#define UBX_RX_NAV_PVT_FLAGS_GNSSFIXOK		0x01	/**< gnssFixOK (A valid fix (i.e within DOP & accuracy masks)) */
-#define UBX_RX_NAV_PVT_FLAGS_DIFFSOLN		0x02	/**< diffSoln (1 if differential corrections were applied) */
-#define UBX_RX_NAV_PVT_FLAGS_PSMSTATE		0x1C	/**< psmState (Power Save Mode state (see Power Management)) */
-#define UBX_RX_NAV_PVT_FLAGS_HEADVEHVALID	0x20	/**< headVehValid (Heading of vehicle is valid) */
-#define UBX_RX_NAV_PVT_FLAGS_CARRSOLN		0xC0	/**< Carrier phase range solution (RTK mode) */
+#define UBX_RX_NAV_PVT_FLAGS_GNSSFIXOK          0x01    /**< gnssFixOK (A valid fix (i.e within DOP & accuracy masks)) */
+#define UBX_RX_NAV_PVT_FLAGS_DIFFSOLN           0x02    /**< diffSoln (1 if differential corrections were applied) */
+#define UBX_RX_NAV_PVT_FLAGS_PSMSTATE           0x1C    /**< psmState (Power Save Mode state (see Power Management)) */
+#define UBX_RX_NAV_PVT_FLAGS_HEADVEHVALID       0x20    /**< headVehValid (Heading of vehicle is valid) */
+#define UBX_RX_NAV_PVT_FLAGS_CARRSOLN           0xC0    /**< Carrier phase range solution (RTK mode) */
 
 /* RX NAV-TIMEUTC message content details */
 /*   Bitfield "valid" masks */
-#define UBX_RX_NAV_TIMEUTC_VALID_VALIDTOW	0x01	/**< validTOW (1 = Valid Time of Week) */
-#define UBX_RX_NAV_TIMEUTC_VALID_VALIDKWN	0x02	/**< validWKN (1 = Valid Week Number) */
-#define UBX_RX_NAV_TIMEUTC_VALID_VALIDUTC	0x04	/**< validUTC (1 = Valid UTC Time) */
-#define UBX_RX_NAV_TIMEUTC_VALID_UTCSTANDARD	0xF0	/**< utcStandard (0..15 = UTC standard identifier) */
+#define UBX_RX_NAV_TIMEUTC_VALID_VALIDTOW       0x01    /**< validTOW (1 = Valid Time of Week) */
+#define UBX_RX_NAV_TIMEUTC_VALID_VALIDKWN       0x02    /**< validWKN (1 = Valid Week Number) */
+#define UBX_RX_NAV_TIMEUTC_VALID_VALIDUTC       0x04    /**< validUTC (1 = Valid UTC Time) */
+#define UBX_RX_NAV_TIMEUTC_VALID_UTCSTANDARD    0xF0    /**< utcStandard (0..15 = UTC standard identifier) */
 
 /* TX CFG-PRT message contents
  * Note: not used with protocol version 27+ anymore
  */
-#define UBX_TX_CFG_PRT_PORTID		0x01		/**< UART1 */
-#define UBX_TX_CFG_PRT_PORTID_USB	0x03		/**< USB */
-#define UBX_TX_CFG_PRT_PORTID_SPI	0x04		/**< SPI */
-#define UBX_TX_CFG_PRT_MODE		0x000008D0	/**< 0b0000100011010000: 8N1 */
-#define UBX_TX_CFG_PRT_MODE_SPI	0x00000100
-#define UBX_TX_CFG_PRT_BAUDRATE		38400		/**< choose 38400 as GPS baudrate (pre M8* boards only) */
-#define UBX_TX_CFG_PRT_INPROTOMASK_GPS	((1<<5) | 0x01)	/**< RTCM3 in and UBX in */
-#define UBX_TX_CFG_PRT_INPROTOMASK_RTCM	(0x01)	/**< UBX in */
-#define UBX_TX_CFG_PRT_OUTPROTOMASK_GPS	(0x01)			/**< UBX out */
-#define UBX_TX_CFG_PRT_OUTPROTOMASK_RTCM	((1<<5) | 0x01)		/**< RTCM3 out and UBX out */
+#define UBX_TX_CFG_PRT_PORTID                   0x01            /**< UART1 */
+#define UBX_TX_CFG_PRT_PORTID_USB               0x03            /**< USB */
+#define UBX_TX_CFG_PRT_PORTID_SPI               0x04            /**< SPI */
+#define UBX_TX_CFG_PRT_MODE                     0x000008D0      /**< 0b0000100011010000: 8N1 */
+#define UBX_TX_CFG_PRT_MODE_SPI                 0x00000100
+#define UBX_TX_CFG_PRT_BAUDRATE                 38400           /**< choose 38400 as GPS baudrate (pre M8* boards only) */
+#define UBX_TX_CFG_PRT_INPROTOMASK_GPS          ((1<<5) | 0x01) /**< RTCM3 in and UBX in */
+#define UBX_TX_CFG_PRT_INPROTOMASK_RTCM         (0x01)          /**< UBX in */
+#define UBX_TX_CFG_PRT_OUTPROTOMASK_GPS         (0x01)          /**< UBX out */
+#define UBX_TX_CFG_PRT_OUTPROTOMASK_RTCM        ((1<<5) | 0x01) /**< RTCM3 out and UBX out */
 
-#define UBX_BAUDRATE_M8_AND_NEWER 115200 /**< baudrate for M8+ boards */
+#define UBX_BAUDRATE_M8_AND_NEWER               115200 /**< baudrate for M8+ boards */
 
 /* TX CFG-RATE message contents
  * Note: not used with protocol version 27+ anymore
  */
-#define UBX_TX_CFG_RATE_MEASINTERVAL		200		/**< 200ms for 5Hz (F9* boards use 10Hz) */
-#define UBX_TX_CFG_RATE_NAVRATE		1		/**< cannot be changed */
-#define UBX_TX_CFG_RATE_TIMEREF		0		/**< 0: UTC, 1: GPS time */
+#define UBX_TX_CFG_RATE_MEASINTERVAL            200     /**< 200ms for 5Hz (F9* boards use 10Hz) */
+#define UBX_TX_CFG_RATE_NAVRATE                 1       /**< cannot be changed */
+#define UBX_TX_CFG_RATE_TIMEREF                 0       /**< 0: UTC, 1: GPS time */
 
 /* TX CFG-NAV5 message contents
  * Note: not used with protocol version 27+ anymore
  */
-#define UBX_TX_CFG_NAV5_MASK		0x0005		/**< Only update dynamic model and fix mode */
-#define UBX_TX_CFG_NAV5_FIXMODE		2		/**< 1 2D only, 2 3D only, 3 Auto 2D/3D */
+#define UBX_TX_CFG_NAV5_MASK                    0x0005  /**< Only update dynamic model and fix mode */
+#define UBX_TX_CFG_NAV5_FIXMODE                 2       /**< 1 2D only, 2 3D only, 3 Auto 2D/3D */
 
 /* TX CFG-RST message contents
  */
-#define UBX_TX_CFG_RST_BBR_MODE_HOT_START 	0
-#define UBX_TX_CFG_RST_BBR_MODE_WARM_START 	1
-#define UBX_TX_CFG_RST_BBR_MODE_COLD_START 	0xFFFF
-#define UBX_TX_CFG_RST_MODE_HARDWARE 		0
-#define UBX_TX_CFG_RST_MODE_SOFTWARE 		1
+#define UBX_TX_CFG_RST_BBR_MODE_HOT_START       0
+#define UBX_TX_CFG_RST_BBR_MODE_WARM_START      1
+#define UBX_TX_CFG_RST_BBR_MODE_COLD_START      0xFFFF
+#define UBX_TX_CFG_RST_MODE_HARDWARE            0
+#define UBX_TX_CFG_RST_MODE_SOFTWARE            1
 
 /* Key ID's for CFG-VAL{GET,SET,DEL} */
-#define UBX_CFG_KEY_CFG_UART1_BAUDRATE           0x40520001
-#define UBX_CFG_KEY_CFG_UART1_STOPBITS           0x20520002
-#define UBX_CFG_KEY_CFG_UART1_DATABITS           0x20520003
-#define UBX_CFG_KEY_CFG_UART1_PARITY             0x20520004
-#define UBX_CFG_KEY_CFG_UART1_ENABLED            0x20520005
-#define UBX_CFG_KEY_CFG_UART1_REMAP              0x20520006
-#define UBX_CFG_KEY_CFG_UART1INPROT_UBX          0x10730001
-#define UBX_CFG_KEY_CFG_UART1INPROT_NMEA         0x10730002
-#define UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X       0x10730004
-#define UBX_CFG_KEY_CFG_UART1OUTPROT_UBX         0x10740001
-#define UBX_CFG_KEY_CFG_UART1OUTPROT_NMEA        0x10740002
-#define UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X      0x10740004
+#define UBX_CFG_KEY_CFG_UART1_BAUDRATE          0x40520001
+#define UBX_CFG_KEY_CFG_UART1_STOPBITS          0x20520002
+#define UBX_CFG_KEY_CFG_UART1_DATABITS          0x20520003
+#define UBX_CFG_KEY_CFG_UART1_PARITY            0x20520004
+#define UBX_CFG_KEY_CFG_UART1_ENABLED           0x20520005
+#define UBX_CFG_KEY_CFG_UART1_REMAP             0x20520006
+#define UBX_CFG_KEY_CFG_UART1INPROT_UBX         0x10730001
+#define UBX_CFG_KEY_CFG_UART1INPROT_NMEA        0x10730002
+#define UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X      0x10730004
+#define UBX_CFG_KEY_CFG_UART1OUTPROT_UBX        0x10740001
+#define UBX_CFG_KEY_CFG_UART1OUTPROT_NMEA       0x10740002
+#define UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X     0x10740004
 
-#define UBX_CFG_KEY_CFG_UART2_BAUDRATE           0x40530001
-#define UBX_CFG_KEY_CFG_UART2_STOPBITS           0x20530002
-#define UBX_CFG_KEY_CFG_UART2_DATABITS           0x20530003
-#define UBX_CFG_KEY_CFG_UART2_PARITY             0x20530004
-#define UBX_CFG_KEY_CFG_UART2_ENABLED            0x20530005
-#define UBX_CFG_KEY_CFG_UART2_REMAP              0x20530006
-#define UBX_CFG_KEY_CFG_UART2INPROT_UBX          0x10750001
-#define UBX_CFG_KEY_CFG_UART2INPROT_NMEA         0x10750002
-#define UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X       0x10750004
-#define UBX_CFG_KEY_CFG_UART2OUTPROT_UBX         0x10760001
-#define UBX_CFG_KEY_CFG_UART2OUTPROT_NMEA        0x10760002
-#define UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X      0x10760004
+#define UBX_CFG_KEY_CFG_UART2_BAUDRATE          0x40530001
+#define UBX_CFG_KEY_CFG_UART2_STOPBITS          0x20530002
+#define UBX_CFG_KEY_CFG_UART2_DATABITS          0x20530003
+#define UBX_CFG_KEY_CFG_UART2_PARITY            0x20530004
+#define UBX_CFG_KEY_CFG_UART2_ENABLED           0x20530005
+#define UBX_CFG_KEY_CFG_UART2_REMAP             0x20530006
+#define UBX_CFG_KEY_CFG_UART2INPROT_UBX         0x10750001
+#define UBX_CFG_KEY_CFG_UART2INPROT_NMEA        0x10750002
+#define UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X      0x10750004
+#define UBX_CFG_KEY_CFG_UART2OUTPROT_UBX        0x10760001
+#define UBX_CFG_KEY_CFG_UART2OUTPROT_NMEA       0x10760002
+#define UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X     0x10760004
 
-#define UBX_CFG_KEY_CFG_USB_ENABLED              0x10650001
-#define UBX_CFG_KEY_CFG_USBINPROT_UBX            0x10770001
-#define UBX_CFG_KEY_CFG_USBINPROT_NMEA           0x10770002
-#define UBX_CFG_KEY_CFG_USBINPROT_RTCM3X         0x10770004
-#define UBX_CFG_KEY_CFG_USBOUTPROT_UBX           0x10780001
-#define UBX_CFG_KEY_CFG_USBOUTPROT_NMEA          0x10780002
-#define UBX_CFG_KEY_CFG_USBOUTPROT_RTCM3X        0x10780004
+#define UBX_CFG_KEY_CFG_USB_ENABLED             0x10650001
+#define UBX_CFG_KEY_CFG_USBINPROT_UBX           0x10770001
+#define UBX_CFG_KEY_CFG_USBINPROT_NMEA          0x10770002
+#define UBX_CFG_KEY_CFG_USBINPROT_RTCM3X        0x10770004
+#define UBX_CFG_KEY_CFG_USBOUTPROT_UBX          0x10780001
+#define UBX_CFG_KEY_CFG_USBOUTPROT_NMEA         0x10780002
+#define UBX_CFG_KEY_CFG_USBOUTPROT_RTCM3X       0x10780004
 
-#define UBX_CFG_KEY_CFG_SPIINPROT_UBX            0x10790001
-#define UBX_CFG_KEY_CFG_SPIINPROT_NMEA           0x10790002
-#define UBX_CFG_KEY_CFG_SPIINPROT_RTCM3X         0x10790004
-#define UBX_CFG_KEY_CFG_SPIOUTPROT_UBX           0x107a0001
-#define UBX_CFG_KEY_CFG_SPIOUTPROT_NMEA          0x107a0002
-#define UBX_CFG_KEY_CFG_SPIOUTPROT_RTCM3X        0x107a0004
+#define UBX_CFG_KEY_CFG_SPIINPROT_UBX           0x10790001
+#define UBX_CFG_KEY_CFG_SPIINPROT_NMEA          0x10790002
+#define UBX_CFG_KEY_CFG_SPIINPROT_RTCM3X        0x10790004
+#define UBX_CFG_KEY_CFG_SPIOUTPROT_UBX          0x107a0001
+#define UBX_CFG_KEY_CFG_SPIOUTPROT_NMEA         0x107a0002
+#define UBX_CFG_KEY_CFG_SPIOUTPROT_RTCM3X       0x107a0004
 
-#define UBX_CFG_KEY_NAVHPG_DGNSSMODE             0x20140011
+#define UBX_CFG_KEY_NAVHPG_DGNSSMODE            0x20140011
 
-#define UBX_CFG_KEY_NAVSPG_FIXMODE               0x20110011
-#define UBX_CFG_KEY_NAVSPG_UTCSTANDARD           0x2011001c
-#define UBX_CFG_KEY_NAVSPG_DYNMODEL              0x20110021
+#define UBX_CFG_KEY_NAVSPG_FIXMODE              0x20110011
+#define UBX_CFG_KEY_NAVSPG_UTCSTANDARD          0x2011001c
+#define UBX_CFG_KEY_NAVSPG_DYNMODEL             0x20110021
 
-#define UBX_CFG_KEY_ODO_USE_ODO                  0x10220001
-#define UBX_CFG_KEY_ODO_USE_COG                  0x10220002
-#define UBX_CFG_KEY_ODO_OUTLPVEL                 0x10220003
-#define UBX_CFG_KEY_ODO_OUTLPCOG                 0x10220004
+#define UBX_CFG_KEY_ODO_USE_ODO                 0x10220001
+#define UBX_CFG_KEY_ODO_USE_COG                 0x10220002
+#define UBX_CFG_KEY_ODO_OUTLPVEL                0x10220003
+#define UBX_CFG_KEY_ODO_OUTLPCOG                0x10220004
 
-#define UBX_CFG_KEY_RATE_MEAS                    0x30210001
-#define UBX_CFG_KEY_RATE_NAV                     0x30210002
-#define UBX_CFG_KEY_RATE_TIMEREF                 0x20210003
+#define UBX_CFG_KEY_RATE_MEAS                   0x30210001
+#define UBX_CFG_KEY_RATE_NAV                    0x30210002
+#define UBX_CFG_KEY_RATE_TIMEREF                0x20210003
 
-#define UBX_CFG_KEY_TMODE_MODE                   0x20030001
-#define UBX_CFG_KEY_TMODE_POS_TYPE               0x20030002
-#define UBX_CFG_KEY_TMODE_LAT                    0x40030009
-#define UBX_CFG_KEY_TMODE_LON                    0x4003000a
-#define UBX_CFG_KEY_TMODE_HEIGHT                 0x4003000b
-#define UBX_CFG_KEY_TMODE_LAT_HP                 0x2003000c
-#define UBX_CFG_KEY_TMODE_LON_HP                 0x2003000d
-#define UBX_CFG_KEY_TMODE_HEIGHT_HP              0x2003000e
-#define UBX_CFG_KEY_TMODE_FIXED_POS_ACC          0x4003000f
-#define UBX_CFG_KEY_TMODE_SVIN_MIN_DUR           0x40030010
-#define UBX_CFG_KEY_TMODE_SVIN_ACC_LIMIT         0x40030011
+#define UBX_CFG_KEY_TMODE_MODE                  0x20030001
+#define UBX_CFG_KEY_TMODE_POS_TYPE              0x20030002
+#define UBX_CFG_KEY_TMODE_LAT                   0x40030009
+#define UBX_CFG_KEY_TMODE_LON                   0x4003000a
+#define UBX_CFG_KEY_TMODE_HEIGHT                0x4003000b
+#define UBX_CFG_KEY_TMODE_LAT_HP                0x2003000c
+#define UBX_CFG_KEY_TMODE_LON_HP                0x2003000d
+#define UBX_CFG_KEY_TMODE_HEIGHT_HP             0x2003000e
+#define UBX_CFG_KEY_TMODE_FIXED_POS_ACC         0x4003000f
+#define UBX_CFG_KEY_TMODE_SVIN_MIN_DUR          0x40030010
+#define UBX_CFG_KEY_TMODE_SVIN_ACC_LIMIT        0x40030011
 
-#define UBX_CFG_KEY_MSGOUT_UBX_MON_RF_I2C        0x20910359
-#define UBX_CFG_KEY_MSGOUT_UBX_NAV_SVIN_I2C      0x20910088
-#define UBX_CFG_KEY_MSGOUT_UBX_NAV_SAT_I2C       0x20910015
-#define UBX_CFG_KEY_MSGOUT_UBX_NAV_DOP_I2C       0x20910038
-#define UBX_CFG_KEY_MSGOUT_UBX_NAV_PVT_I2C       0x20910006
-#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1005_I2C  0x209102bd
-#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_I2C  0x209102cc
-#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_I2C  0x209102d1
-#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_I2C  0x20910318
-#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_I2C  0x209102d6
-#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_I2C  0x20910303
+#define UBX_CFG_KEY_MSGOUT_UBX_MON_RF_I2C       0x20910359
+#define UBX_CFG_KEY_MSGOUT_UBX_NAV_SVIN_I2C     0x20910088
+#define UBX_CFG_KEY_MSGOUT_UBX_NAV_SAT_I2C      0x20910015
+#define UBX_CFG_KEY_MSGOUT_UBX_NAV_DOP_I2C      0x20910038
+#define UBX_CFG_KEY_MSGOUT_UBX_NAV_PVT_I2C      0x20910006
+#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1005_I2C 0x209102bd
+#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_I2C 0x209102cc
+#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_I2C 0x209102d1
+#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_I2C 0x20910318
+#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_I2C 0x209102d6
+#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_I2C 0x20910303
 
-#define UBX_CFG_KEY_SPI_ENABLED                  0x10640006
-#define UBX_CFG_KEY_SPI_MAXFF                    0x20640001
+#define UBX_CFG_KEY_SPI_ENABLED                 0x10640006
+#define UBX_CFG_KEY_SPI_MAXFF                   0x20640001
 
+#define UBX_PAYLOAD_RX_NAV_PVT_SIZE_UBX7        (sizeof(ubx_payload_rx_nav_pvt_t) - 8)
+#define UBX_PAYLOAD_RX_NAV_PVT_SIZE_UBX8        (sizeof(ubx_payload_rx_nav_pvt_t))
 
+#define UBX_CFG_LAYER_RAM                       (1 << 0)
+#define UBX_CFG_LAYER_BBR                       (1 << 1)
+#define UBX_CFG_LAYER_FLASH                     (1 << 2)
+
+// Forward Declaration
 class RTCMParsing;
 
 
@@ -305,230 +312,227 @@ class RTCMParsing;
 
 /* General: Header */
 typedef struct {
-	uint8_t		sync1;
-	uint8_t		sync2;
-	uint16_t	msg;
-	uint16_t	length;
+	uint8_t  sync1;
+	uint8_t  sync2;
+	uint16_t msg;
+	uint16_t length;
 } ubx_header_t;
 
 /* General: Checksum */
 typedef struct {
-	uint8_t		ck_a;
-	uint8_t		ck_b;
+	uint8_t ck_a;
+	uint8_t ck_b;
 } ubx_checksum_t ;
 
 /* Rx NAV-POSLLH */
 typedef struct {
-	uint32_t	iTOW;		/**< GPS Time of Week [ms] */
-	int32_t		lon;		/**< Longitude [1e-7 deg] */
-	int32_t		lat;		/**< Latitude [1e-7 deg] */
-	int32_t		height;		/**< Height above ellipsoid [mm] */
-	int32_t		hMSL;		/**< Height above mean sea level [mm] */
-	uint32_t	hAcc;  		/**< Horizontal accuracy estimate [mm] */
-	uint32_t	vAcc;  		/**< Vertical accuracy estimate [mm] */
+	uint32_t iTOW;   /**< GPS Time of Week [ms] */
+	int32_t  lon;    /**< Longitude [1e-7 deg] */
+	int32_t  lat;    /**< Latitude [1e-7 deg] */
+	int32_t  height; /**< Height above ellipsoid [mm] */
+	int32_t  hMSL;   /**< Height above mean sea level [mm] */
+	uint32_t hAcc;   /**< Horizontal accuracy estimate [mm] */
+	uint32_t vAcc;   /**< Vertical accuracy estimate [mm] */
 } ubx_payload_rx_nav_posllh_t;
 
 /* Rx NAV-DOP */
 typedef struct {
-	uint32_t	iTOW;		/**< GPS Time of Week [ms] */
-	uint16_t	gDOP;		/**< Geometric DOP [0.01] */
-	uint16_t	pDOP;		/**< Position DOP [0.01] */
-	uint16_t	tDOP;		/**< Time DOP [0.01] */
-	uint16_t	vDOP;		/**< Vertical DOP [0.01] */
-	uint16_t	hDOP;		/**< Horizontal DOP [0.01] */
-	uint16_t	nDOP;		/**< Northing DOP [0.01] */
-	uint16_t	eDOP;		/**< Easting DOP [0.01] */
+	uint32_t iTOW; /**< GPS Time of Week [ms] */
+	uint16_t gDOP; /**< Geometric DOP [0.01] */
+	uint16_t pDOP; /**< Position DOP [0.01] */
+	uint16_t tDOP; /**< Time DOP [0.01] */
+	uint16_t vDOP; /**< Vertical DOP [0.01] */
+	uint16_t hDOP; /**< Horizontal DOP [0.01] */
+	uint16_t nDOP; /**< Northing DOP [0.01] */
+	uint16_t eDOP; /**< Easting DOP [0.01] */
 } ubx_payload_rx_nav_dop_t;
 
 /* Rx NAV-SOL */
 typedef struct {
-	uint32_t	iTOW;		/**< GPS Time of Week [ms] */
-	int32_t		fTOW;		/**< Fractional part of iTOW (range: +/-500000) [ns] */
-	int16_t		week;		/**< GPS week */
-	uint8_t		gpsFix;		/**< GPSfix type: 0 = No fix, 1 = Dead Reckoning only, 2 = 2D fix, 3 = 3d-fix, 4 = GPS + dead reckoning, 5 = time only fix */
-	uint8_t		flags;
-	int32_t		ecefX;
-	int32_t		ecefY;
-	int32_t		ecefZ;
-	uint32_t	pAcc;
-	int32_t		ecefVX;
-	int32_t		ecefVY;
-	int32_t		ecefVZ;
-	uint32_t	sAcc;
-	uint16_t	pDOP;		/**< Position DOP [0.01] */
-	uint8_t		reserved1;
-	uint8_t		numSV;		/**< Number of SVs used in Nav Solution */
-	uint32_t	reserved2;
+	uint32_t iTOW;     /**< GPS Time of Week [ms] */
+	int32_t  fTOW;     /**< Fractional part of iTOW (range: +/-500000) [ns] */
+	int16_t  week;     /**< GPS week */
+	uint8_t  gpsFix;   /**< GPSfix type: 0 = No fix, 1 = Dead Reckoning only, 2 = 2D fix, 3 = 3d-fix, 4 = GPS + dead reckoning, 5 = time only fix */
+	uint8_t  flags;
+	int32_t  ecefX;
+	int32_t  ecefY;
+	int32_t  ecefZ;
+	uint32_t pAcc;
+	int32_t  ecefVX;
+	int32_t  ecefVY;
+	int32_t  ecefVZ;
+	uint32_t sAcc;
+	uint16_t pDOP;      /**< Position DOP [0.01] */
+	uint8_t  reserved1;
+	uint8_t  numSV;     /**< Number of SVs used in Nav Solution */
+	uint32_t reserved2;
 } ubx_payload_rx_nav_sol_t;
 
 /* Rx NAV-PVT (ubx8) */
 typedef struct {
-	uint32_t	iTOW;		/**< GPS Time of Week [ms] */
-	uint16_t	year; 		/**< Year (UTC)*/
-	uint8_t		month; 		/**< Month, range 1..12 (UTC) */
-	uint8_t		day; 		/**< Day of month, range 1..31 (UTC) */
-	uint8_t		hour; 		/**< Hour of day, range 0..23 (UTC) */
-	uint8_t		min; 		/**< Minute of hour, range 0..59 (UTC) */
-	uint8_t		sec;		/**< Seconds of minute, range 0..60 (UTC) */
-	uint8_t		valid; 		/**< Validity flags (see UBX_RX_NAV_PVT_VALID_...) */
-	uint32_t	tAcc; 		/**< Time accuracy estimate (UTC) [ns] */
-	int32_t		nano;		/**< Fraction of second (UTC) [-1e9...1e9 ns] */
-	uint8_t		fixType;	/**< GNSSfix type: 0 = No fix, 1 = Dead Reckoning only, 2 = 2D fix, 3 = 3d-fix, 4 = GNSS + dead reckoning, 5 = time only fix */
-	uint8_t		flags;		/**< Fix Status Flags (see UBX_RX_NAV_PVT_FLAGS_...) */
-	uint8_t		reserved1;
-	uint8_t		numSV;		/**< Number of SVs used in Nav Solution */
-	int32_t		lon;		/**< Longitude [1e-7 deg] */
-	int32_t		lat;		/**< Latitude [1e-7 deg] */
-	int32_t		height;		/**< Height above ellipsoid [mm] */
-	int32_t		hMSL;		/**< Height above mean sea level [mm] */
-	uint32_t	hAcc;  		/**< Horizontal accuracy estimate [mm] */
-	uint32_t	vAcc;  		/**< Vertical accuracy estimate [mm] */
-	int32_t		velN;		/**< NED north velocity [mm/s]*/
-	int32_t		velE;		/**< NED east velocity [mm/s]*/
-	int32_t		velD;		/**< NED down velocity [mm/s]*/
-	int32_t		gSpeed;		/**< Ground Speed (2-D) [mm/s] */
-	int32_t		headMot;	/**< Heading of motion (2-D) [1e-5 deg] */
-	uint32_t	sAcc;		/**< Speed accuracy estimate [mm/s] */
-	uint32_t	headAcc;	/**< Heading accuracy estimate (motion and vehicle) [1e-5 deg] */
-	uint16_t	pDOP;		/**< Position DOP [0.01] */
-	uint16_t	reserved2;
-	uint32_t	reserved3;
-	int32_t		headVeh;	/**< (ubx8+ only) Heading of vehicle (2-D) [1e-5 deg] */
-	uint32_t	reserved4;	/**< (ubx8+ only) */
+	uint32_t iTOW;          /**< GPS Time of Week [ms] */
+	uint16_t year;          /**< Year (UTC)*/
+	uint8_t  month;         /**< Month, range 1..12 (UTC) */
+	uint8_t  day;           /**< Day of month, range 1..31 (UTC) */
+	uint8_t  hour;          /**< Hour of day, range 0..23 (UTC) */
+	uint8_t  min;           /**< Minute of hour, range 0..59 (UTC) */
+	uint8_t  sec;           /**< Seconds of minute, range 0..60 (UTC) */
+	uint8_t  valid;         /**< Validity flags (see UBX_RX_NAV_PVT_VALID_...) */
+	uint32_t tAcc;          /**< Time accuracy estimate (UTC) [ns] */
+	int32_t  nano;          /**< Fraction of second (UTC) [-1e9...1e9 ns] */
+	uint8_t  fixType;       /**< GNSSfix type: 0 = No fix, 1 = Dead Reckoning only, 2 = 2D fix, 3 = 3d-fix, 4 = GNSS + dead reckoning, 5 = time only fix */
+	uint8_t  flags;         /**< Fix Status Flags (see UBX_RX_NAV_PVT_FLAGS_...) */
+	uint8_t  reserved1;
+	uint8_t  numSV;         /**< Number of SVs used in Nav Solution */
+	int32_t  lon;           /**< Longitude [1e-7 deg] */
+	int32_t  lat;           /**< Latitude [1e-7 deg] */
+	int32_t  height;        /**< Height above ellipsoid [mm] */
+	int32_t  hMSL;          /**< Height above mean sea level [mm] */
+	uint32_t hAcc;          /**< Horizontal accuracy estimate [mm] */
+	uint32_t vAcc;          /**< Vertical accuracy estimate [mm] */
+	int32_t  velN;          /**< NED north velocity [mm/s]*/
+	int32_t  velE;          /**< NED east velocity [mm/s]*/
+	int32_t  velD;          /**< NED down velocity [mm/s]*/
+	int32_t  gSpeed;        /**< Ground Speed (2-D) [mm/s] */
+	int32_t  headMot;       /**< Heading of motion (2-D) [1e-5 deg] */
+	uint32_t sAcc;          /**< Speed accuracy estimate [mm/s] */
+	uint32_t headAcc;       /**< Heading accuracy estimate (motion and vehicle) [1e-5 deg] */
+	uint16_t pDOP;          /**< Position DOP [0.01] */
+	uint16_t reserved2;
+	uint32_t reserved3;
+	int32_t  headVeh;       /**< (ubx8+ only) Heading of vehicle (2-D) [1e-5 deg] */
+	uint32_t reserved4;     /**< (ubx8+ only) */
 } ubx_payload_rx_nav_pvt_t;
-#define UBX_PAYLOAD_RX_NAV_PVT_SIZE_UBX7	(sizeof(ubx_payload_rx_nav_pvt_t) - 8)
-#define UBX_PAYLOAD_RX_NAV_PVT_SIZE_UBX8	(sizeof(ubx_payload_rx_nav_pvt_t))
 
 /* Rx NAV-TIMEUTC */
 typedef struct {
-	uint32_t	iTOW;		/**< GPS Time of Week [ms] */
-	uint32_t	tAcc; 		/**< Time accuracy estimate (UTC) [ns] */
-	int32_t		nano;		/**< Fraction of second, range -1e9 .. 1e9 (UTC) [ns] */
-	uint16_t	year; 		/**< Year, range 1999..2099 (UTC) */
-	uint8_t		month; 		/**< Month, range 1..12 (UTC) */
-	uint8_t		day; 		/**< Day of month, range 1..31 (UTC) */
-	uint8_t		hour; 		/**< Hour of day, range 0..23 (UTC) */
-	uint8_t		min; 		/**< Minute of hour, range 0..59 (UTC) */
-	uint8_t		sec;		/**< Seconds of minute, range 0..60 (UTC) */
-	uint8_t		valid; 		/**< Validity Flags (see UBX_RX_NAV_TIMEUTC_VALID_...) */
+	uint32_t iTOW;           /**< GPS Time of Week [ms] */
+	uint32_t tAcc;           /**< Time accuracy estimate (UTC) [ns] */
+	int32_t  nano;           /**< Fraction of second, range -1e9 .. 1e9 (UTC) [ns] */
+	uint16_t year;           /**< Year, range 1999..2099 (UTC) */
+	uint8_t  month;          /**< Month, range 1..12 (UTC) */
+	uint8_t  day;            /**< Day of month, range 1..31 (UTC) */
+	uint8_t  hour;           /**< Hour of day, range 0..23 (UTC) */
+	uint8_t  min;            /**< Minute of hour, range 0..59 (UTC) */
+	uint8_t  sec;            /**< Seconds of minute, range 0..60 (UTC) */
+	uint8_t  valid;          /**< Validity Flags (see UBX_RX_NAV_TIMEUTC_VALID_...) */
 } ubx_payload_rx_nav_timeutc_t;
 
 /* Rx NAV-SVINFO Part 1 */
 typedef struct {
-	uint32_t	iTOW;		/**< GPS Time of Week [ms] */
-	uint8_t		numCh; 		/**< Number of channels */
-	uint8_t		globalFlags;
-	uint16_t	reserved2;
+	uint32_t iTOW;           /**< GPS Time of Week [ms] */
+	uint8_t  numCh;          /**< Number of channels */
+	uint8_t  globalFlags;
+	uint16_t reserved2;
 } ubx_payload_rx_nav_svinfo_part1_t;
 
 /* Rx NAV-SVINFO Part 2 (repeated) */
 typedef struct {
-	uint8_t		chn;            /**< Channel number, 255 for SVs not assigned to a channel */
-	uint8_t		svid;           /**< Satellite ID */
-	uint8_t		flags;
-	uint8_t		quality;
-	int8_t		elev;           /**< Elevation [deg] */
-	int16_t		azim;           /**< Azimuth [deg] */
-	uint8_t		cno;            /**< Carrier to Noise Ratio (Signal Strength) [dbHz] */
-	uint8_t		snr;            /**< Signal to Noise Ratio */
-	uint8_t		prn;            /**< Psuedo Random Number SBAS code, [120-144] */
-	int32_t		prRes;          /**< Pseudo range residual [cm] */
+	uint8_t chn;            /**< Channel number, 255 for SVs not assigned to a channel */
+	uint8_t svid;           /**< Satellite ID */
+	uint8_t flags;
+	uint8_t quality;
+	int8_t  elev;           /**< Elevation [deg] */
+	int16_t azim;           /**< Azimuth [deg] */
+	uint8_t cno;            /**< Carrier to Noise Ratio (Signal Strength) [dbHz] */
+	uint8_t snr;            /**< Signal to Noise Ratio */
+	uint8_t prn;            /**< Psuedo Random Number SBAS code, [120-144] */
+	int32_t prRes;          /**< Pseudo range residual [cm] */
 } ubx_payload_rx_nav_svinfo_part2_t;
-
 
 /* Rx NAV-SAT Part 1 */
 typedef struct {
-	uint32_t	iTOW;		/**< GPS Time of Week [ms] */
-	uint8_t		version; 	/**< Message version (1) */
-	uint8_t		numSvs;		/**< Number of Satellites */
-	uint16_t	reserved;
+	uint32_t iTOW;           /**< GPS Time of Week [ms] */
+	uint8_t  version;        /**< Message version (1) */
+	uint8_t  numSvs;         /**< Number of Satellites */
+	uint16_t reserved;
 } ubx_payload_rx_nav_sat_part1_t;
 
 /* Rx NAV-SAT Part 2 (repeated) */
 typedef struct {
-	uint8_t		gnssId;         /**< GNSS identifier */
-	uint8_t		svId;           /**< Satellite ID */
-	int8_t		elev;           /**< Elevation [deg] range: +/-90 */
-	int16_t		azim;           /**< Azimuth [deg] range: 0-360 */
-	uint8_t		cno;            /**< Carrier to Noise Ratio (Signal Strength) [dbHz] */
-	uint8_t		prn;            /**< Psuedo Random Number SBAS code, [120-144] */
-	int16_t		prRes;          /**< Pseudo range residual [0.1 m] */
-	uint32_t	flags;
+	uint8_t  gnssId;         /**< GNSS identifier */
+	uint8_t  svId;           /**< Satellite ID */
+	int8_t   elev;           /**< Elevation [deg] range: +/-90 */
+	int16_t  azim;           /**< Azimuth [deg] range: 0-360 */
+	uint8_t  cno;            /**< Carrier to Noise Ratio (Signal Strength) [dbHz] */
+	uint8_t  prn;            /**< Psuedo Random Number SBAS code, [120-144] */
+	int16_t  prRes;          /**< Pseudo range residual [0.1 m] */
+	uint32_t flags;
 } ubx_payload_rx_nav_sat_part2_t;
 
 /* Rx NAV-SVIN (survey-in info) */
 typedef struct {
-	uint8_t     version;
-	uint8_t     reserved1[3];
-	uint32_t	iTOW;
-	uint32_t    dur;
-	int32_t     meanX;
-	int32_t     meanY;
-	int32_t     meanZ;
-	int8_t      meanXHP;
-	int8_t      meanYHP;
-	int8_t      meanZHP;
-	int8_t      reserved2;
-	uint32_t    meanAcc;
-	uint32_t    obs;
-	uint8_t     valid;
-	uint8_t     active;
-	uint8_t     reserved3[2];
+	uint8_t  version;
+	uint8_t  reserved1[3];
+	uint32_t iTOW;
+	uint32_t dur;
+	int32_t  meanX;
+	int32_t  meanY;
+	int32_t  meanZ;
+	int8_t   meanXHP;
+	int8_t   meanYHP;
+	int8_t   meanZHP;
+	int8_t   reserved2;
+	uint32_t meanAcc;
+	uint32_t obs;
+	uint8_t  valid;
+	uint8_t  active;
+	uint8_t  reserved3[2];
 } ubx_payload_rx_nav_svin_t;
 
 /* Rx NAV-VELNED */
 typedef struct {
-	uint32_t	iTOW;		/**< GPS Time of Week [ms] */
-	int32_t		velN;		/**< North velocity component [cm/s]*/
-	int32_t		velE;		/**< East velocity component [cm/s]*/
-	int32_t		velD;		/**< Down velocity component [cm/s]*/
-	uint32_t	speed;		/**< Speed (3-D) [cm/s] */
-	uint32_t	gSpeed;		/**< Ground speed (2-D) [cm/s] */
-	int32_t		heading;	/**< Heading of motion 2-D [1e-5 deg] */
-	uint32_t	sAcc;		/**< Speed accuracy estimate [cm/s] */
-	uint32_t	cAcc;		/**< Course / Heading accuracy estimate [1e-5 deg] */
+	uint32_t iTOW;           /**< GPS Time of Week [ms] */
+	int32_t  velN;           /**< North velocity component [cm/s]*/
+	int32_t  velE;           /**< East velocity component [cm/s]*/
+	int32_t  velD;           /**< Down velocity component [cm/s]*/
+	uint32_t speed;          /**< Speed (3-D) [cm/s] */
+	uint32_t gSpeed;         /**< Ground speed (2-D) [cm/s] */
+	int32_t  heading;        /**< Heading of motion 2-D [1e-5 deg] */
+	uint32_t sAcc;           /**< Speed accuracy estimate [cm/s] */
+	uint32_t cAcc;           /**< Course / Heading accuracy estimate [1e-5 deg] */
 } ubx_payload_rx_nav_velned_t;
 
 /* Rx MON-HW (ubx6) */
 typedef struct {
-	uint32_t	pinSel;
-	uint32_t	pinBank;
-	uint32_t	pinDir;
-	uint32_t	pinVal;
-	uint16_t	noisePerMS;
-	uint16_t	agcCnt;
-	uint8_t		aStatus;
-	uint8_t		aPower;
-	uint8_t		flags;
-	uint8_t		reserved1;
-	uint32_t	usedMask;
-	uint8_t		VP[25];
-	uint8_t		jamInd;
-	uint16_t	reserved3;
-	uint32_t	pinIrq;
-	uint32_t	pullH;
-	uint32_t	pullL;
+	uint32_t pinSel;
+	uint32_t pinBank;
+	uint32_t pinDir;
+	uint32_t pinVal;
+	uint16_t noisePerMS;
+	uint16_t agcCnt;
+	uint8_t  aStatus;
+	uint8_t  aPower;
+	uint8_t  flags;
+	uint8_t  reserved1;
+	uint32_t usedMask;
+	uint8_t  VP[25];
+	uint8_t  jamInd;
+	uint16_t reserved3;
+	uint32_t pinIrq;
+	uint32_t pullH;
+	uint32_t pullL;
 } ubx_payload_rx_mon_hw_ubx6_t;
 
 /* Rx MON-HW (ubx7+) */
 typedef struct {
-	uint32_t	pinSel;
-	uint32_t	pinBank;
-	uint32_t	pinDir;
-	uint32_t	pinVal;
-	uint16_t	noisePerMS;
-	uint16_t	agcCnt;
-	uint8_t		aStatus;
-	uint8_t		aPower;
-	uint8_t		flags;
-	uint8_t		reserved1;
-	uint32_t	usedMask;
-	uint8_t		VP[17];
-	uint8_t		jamInd;
-	uint16_t	reserved3;
-	uint32_t	pinIrq;
-	uint32_t	pullH;
-	uint32_t	pullL;
+	uint32_t pinSel;
+	uint32_t pinBank;
+	uint32_t pinDir;
+	uint32_t pinVal;
+	uint16_t noisePerMS;
+	uint16_t agcCnt;
+	uint8_t  aStatus;
+	uint8_t  aPower;
+	uint8_t  flags;
+	uint8_t  reserved1;
+	uint32_t usedMask;
+	uint8_t  VP[17];
+	uint8_t  jamInd;
+	uint16_t reserved3;
+	uint32_t pinIrq;
+	uint32_t pullH;
+	uint32_t pullL;
 } ubx_payload_rx_mon_hw_ubx7_t;
 
 /* Rx MON-RF (replaces MON-HW, protocol 27+) */
@@ -538,20 +542,20 @@ typedef struct {
 	uint8_t reserved1[2];
 
 	struct ubx_payload_rx_mon_rf_block_t {
-		uint8_t blockId;     /**< RF block id */
-		uint8_t flags;       /**< jammingState */
-		uint8_t antStatus;   /**< Status of the antenna superior state machine */
-		uint8_t antPower;    /**< Current power status of antenna */
-		uint32_t postStatus; /**< POST status word */
-		uint8_t reserved2[4];
-		uint16_t noisePerMS; /**< Noise level as measured by the GPS core */
-		uint16_t agcCnt;     /**< AGC Monitor (counts SIGI xor SIGLO, range 0 to 8191 */
-		uint8_t jamInd;      /**< CW jamming indicator, scaled (0=no CW jamming, 255=strong CW jamming) */
-		int8_t ofsI;         /**< Imbalance of I-part of complex signal */
-		uint8_t magI;        /**< Magnitude of I-part of complex signal (0=no signal, 255=max magnitude) */
-		int8_t ofsQ;         /**< Imbalance of Q-part of complex signal */
-		uint8_t magQ;        /**< Magnitude of Q-part of complex signal (0=no signal, 255=max magnitude) */
-		uint8_t reserved3[3];
+		uint8_t  blockId;       /**< RF block id */
+		uint8_t  flags;         /**< jammingState */
+		uint8_t  antStatus;     /**< Status of the antenna superior state machine */
+		uint8_t  antPower;      /**< Current power status of antenna */
+		uint32_t postStatus;    /**< POST status word */
+		uint8_t  reserved2[4];
+		uint16_t noisePerMS;    /**< Noise level as measured by the GPS core */
+		uint16_t agcCnt;        /**< AGC Monitor (counts SIGI xor SIGLO, range 0 to 8191 */
+		uint8_t  jamInd;        /**< CW jamming indicator, scaled (0=no CW jamming, 255=strong CW jamming) */
+		int8_t   ofsI;          /**< Imbalance of I-part of complex signal */
+		uint8_t  magI;          /**< Magnitude of I-part of complex signal (0=no signal, 255=max magnitude) */
+		int8_t   ofsQ;          /**< Imbalance of Q-part of complex signal */
+		uint8_t  magQ;          /**< Magnitude of Q-part of complex signal (0=no signal, 255=max magnitude) */
+		uint8_t  reserved3[3];
 	};
 
 	ubx_payload_rx_mon_rf_block_t block[1]; ///< only read out the first block
@@ -559,120 +563,116 @@ typedef struct {
 
 /* Rx MON-VER Part 1 */
 typedef struct {
-	uint8_t		swVersion[30];
-	uint8_t		hwVersion[10];
+	uint8_t swVersion[30];
+	uint8_t hwVersion[10];
 } ubx_payload_rx_mon_ver_part1_t;
 
 /* Rx MON-VER Part 2 (repeated) */
 typedef struct {
-	uint8_t		extension[30];
+	uint8_t extension[30];
 } ubx_payload_rx_mon_ver_part2_t;
 
 /* Rx ACK-ACK */
-typedef	union {
-	uint16_t	msg;
+typedef union {
+	uint16_t msg;
 	struct {
-		uint8_t	clsID;
-		uint8_t	msgID;
+		uint8_t clsID;
+		uint8_t msgID;
 	};
 } ubx_payload_rx_ack_ack_t;
 
 /* Rx ACK-NAK */
-typedef	union {
-	uint16_t	msg;
+typedef union {
+	uint16_t msg;
 	struct {
-		uint8_t	clsID;
-		uint8_t	msgID;
+		uint8_t clsID;
+		uint8_t msgID;
 	};
 } ubx_payload_rx_ack_nak_t;
 
 /* Tx CFG-PRT */
 typedef struct {
-	uint8_t		portID;
-	uint8_t		reserved0;
-	uint16_t	txReady;
-	uint32_t	mode;
-	uint32_t	baudRate;
-	uint16_t	inProtoMask;
-	uint16_t	outProtoMask;
-	uint16_t	flags;
-	uint16_t	reserved5;
+	uint8_t  portID;
+	uint8_t  reserved0;
+	uint16_t txReady;
+	uint32_t mode;
+	uint32_t baudRate;
+	uint16_t inProtoMask;
+	uint16_t outProtoMask;
+	uint16_t flags;
+	uint16_t reserved5;
 } ubx_payload_tx_cfg_prt_t;
 
 /* Tx CFG-RATE */
 typedef struct {
-	uint16_t	measRate;	/**< Measurement Rate, GPS measurements are taken every measRate milliseconds */
-	uint16_t	navRate;	/**< Navigation Rate, in number of measurement cycles. This parameter cannot be changed, and must be set to 1 */
-	uint16_t	timeRef;	/**< Alignment to reference time: 0 = UTC time, 1 = GPS time */
+	uint16_t measRate;      /**< Measurement Rate, GPS measurements are taken every measRate milliseconds */
+	uint16_t navRate;       /**< Navigation Rate, in number of measurement cycles. This parameter cannot be changed, and must be set to 1 */
+	uint16_t timeRef;       /**< Alignment to reference time: 0 = UTC time, 1 = GPS time */
 } ubx_payload_tx_cfg_rate_t;
 
 /* Tx CFG-CFG */
 typedef struct {
-	uint32_t	clearMask;	/**< Clear settings */
-	uint32_t	saveMask;	/**< Save settings */
-	uint32_t	loadMask;	/**< Load settings */
-	uint8_t		deviceMask; /**< Storage devices to apply this top */
+	uint32_t clearMask;     /**< Clear settings */
+	uint32_t saveMask;      /**< Save settings */
+	uint32_t loadMask;      /**< Load settings */
+	uint8_t  deviceMask;    /**< Storage devices to apply this top */
 } ubx_payload_tx_cfg_cfg_t;
 
 /* Tx CFG-VALSET (protocol version 27+) */
 typedef struct {
-	uint8_t     version;	/**< Message version, set to 0 */
-	uint8_t     layers;	/**< The layers where the configuration should be applied (@see UBX_CFG_LAYER_*) */
-	uint8_t     reserved1[2];
-	uint8_t		cfgData;	/**< configuration data (key and value pairs, max 64) */
+	uint8_t version;        /**< Message version, set to 0 */
+	uint8_t layers;         /**< The layers where the configuration should be applied (@see UBX_CFG_LAYER_*) */
+	uint8_t reserved1[2];
+	uint8_t cfgData;        /**< configuration data (key and value pairs, max 64) */
 } ubx_payload_tx_cfg_valset_t;
-
-#define UBX_CFG_LAYER_RAM (1 << 0)
-#define UBX_CFG_LAYER_BBR (1 << 1)
-#define UBX_CFG_LAYER_FLASH (1 << 2)
 
 /* Tx CFG-NAV5 */
 typedef struct {
-	uint16_t	mask;
-	uint8_t		dynModel;	/**< Dynamic Platform model: 0 Portable, 2 Stationary, 3 Pedestrian, 4 Automotive, 5 Sea, 6 Airborne <1g, 7 Airborne <2g, 8 Airborne <4g */
-	uint8_t		fixMode;	/**< Position Fixing Mode: 1 2D only, 2 3D only, 3 Auto 2D/3D */
-	int32_t		fixedAlt;
-	uint32_t	fixedAltVar;
-	int8_t		minElev;
-	uint8_t		drLimit;
-	uint16_t	pDop;
-	uint16_t	tDop;
-	uint16_t	pAcc;
-	uint16_t	tAcc;
-	uint8_t		staticHoldThresh;
-	uint8_t		dgpsTimeOut;
-	uint8_t		cnoThreshNumSVs;	/**< (ubx7+ only, else 0) */
-	uint8_t		cnoThresh;		/**< (ubx7+ only, else 0) */
-	uint16_t	reserved;
-	uint16_t	staticHoldMaxDist;	/**< (ubx8+ only, else 0) */
-	uint8_t		utcStandard;		/**< (ubx8+ only, else 0) */
-	uint8_t		reserved3;
-	uint32_t	reserved4;
+	uint16_t mask;
+	uint8_t  dynModel;       /**< Dynamic Platform model: 0 Portable, 2 Stationary, 3 Pedestrian, 4 Automotive, 5 Sea, 6 Airborne <1g, 7 Airborne <2g, 8 Airborne <4g */
+	uint8_t  fixMode;        /**< Position Fixing Mode: 1 2D only, 2 3D only, 3 Auto 2D/3D */
+	int32_t  fixedAlt;
+	uint32_t fixedAltVar;
+	int8_t   minElev;
+	uint8_t  drLimit;
+	uint16_t pDop;
+	uint16_t tDop;
+	uint16_t pAcc;
+	uint16_t tAcc;
+	uint8_t  staticHoldThresh;
+	uint8_t  dgpsTimeOut;
+	uint8_t  cnoThreshNumSVs;        /**< (ubx7+ only, else 0) */
+	uint8_t  cnoThresh;              /**< (ubx7+ only, else 0) */
+	uint16_t reserved;
+	uint16_t staticHoldMaxDist;      /**< (ubx8+ only, else 0) */
+	uint8_t  utcStandard;            /**< (ubx8+ only, else 0) */
+	uint8_t  reserved3;
+	uint32_t reserved4;
 } ubx_payload_tx_cfg_nav5_t;
 
 /* tx cfg-rst */
 typedef struct {
-	uint16_t	navBbrMask;
-	uint8_t		resetMode;
-	uint8_t		reserved1;
+	uint16_t navBbrMask;
+	uint8_t  resetMode;
+	uint8_t  reserved1;
 } ubx_payload_tx_cfg_rst_t;
 
 /* tx cfg-sbas */
 typedef struct {
-	uint8_t		mode;
-	uint8_t		usage;
-	uint8_t		maxSBAS;
-	uint8_t		scanmode2;
-	uint32_t	scanmode1;
+	uint8_t  mode;
+	uint8_t  usage;
+	uint8_t  maxSBAS;
+	uint8_t  scanmode2;
+	uint32_t scanmode1;
 } ubx_payload_tx_cfg_sbas_t;
 
 /* Tx CFG-MSG */
 typedef struct {
 	union {
-		uint16_t	msg;
+		uint16_t msg;
 		struct {
-			uint8_t	msgClass;
-			uint8_t	msgID;
+			uint8_t msgClass;
+			uint8_t msgID;
 		};
 	};
 	uint8_t rate;
@@ -680,51 +680,51 @@ typedef struct {
 
 /* CFG-TMODE3 ublox 8 (protocol version >= 20) */
 typedef struct {
-	uint8_t     version;
-	uint8_t     reserved1;
-	uint16_t    flags;
-	int32_t     ecefXOrLat;
-	int32_t     ecefYOrLon;
-	int32_t     ecefZOrAlt;
-	int8_t      ecefXOrLatHP;
-	int8_t      ecefYOrLonHP;
-	int8_t      ecefZOrAltHP;
-	uint8_t     reserved2;
-	uint32_t    fixedPosAcc;
-	uint32_t    svinMinDur;
-	uint32_t    svinAccLimit;
-	uint8_t     reserved3[8];
+	uint8_t  version;
+	uint8_t  reserved1;
+	uint16_t flags;
+	int32_t  ecefXOrLat;
+	int32_t  ecefYOrLon;
+	int32_t  ecefZOrAlt;
+	int8_t   ecefXOrLatHP;
+	int8_t   ecefYOrLonHP;
+	int8_t   ecefZOrAltHP;
+	uint8_t  reserved2;
+	uint32_t fixedPosAcc;
+	uint32_t svinMinDur;
+	uint32_t svinAccLimit;
+	uint8_t  reserved3[8];
 } ubx_payload_tx_cfg_tmode3_t;
 
 /* General message and payload buffer union */
 typedef union {
-	ubx_payload_rx_nav_pvt_t		payload_rx_nav_pvt;
-	ubx_payload_rx_nav_posllh_t		payload_rx_nav_posllh;
-	ubx_payload_rx_nav_sol_t		payload_rx_nav_sol;
-	ubx_payload_rx_nav_dop_t		payload_rx_nav_dop;
-	ubx_payload_rx_nav_timeutc_t		payload_rx_nav_timeutc;
-	ubx_payload_rx_nav_svinfo_part1_t	payload_rx_nav_svinfo_part1;
-	ubx_payload_rx_nav_svinfo_part2_t	payload_rx_nav_svinfo_part2;
-	ubx_payload_rx_nav_sat_part1_t		payload_rx_nav_sat_part1;
-	ubx_payload_rx_nav_sat_part2_t		payload_rx_nav_sat_part2;
-	ubx_payload_rx_nav_svin_t		payload_rx_nav_svin;
-	ubx_payload_rx_nav_velned_t		payload_rx_nav_velned;
-	ubx_payload_rx_mon_hw_ubx6_t		payload_rx_mon_hw_ubx6;
-	ubx_payload_rx_mon_hw_ubx7_t		payload_rx_mon_hw_ubx7;
-	ubx_payload_rx_mon_rf_t			payload_rx_mon_rf;
-	ubx_payload_rx_mon_ver_part1_t		payload_rx_mon_ver_part1;
-	ubx_payload_rx_mon_ver_part2_t		payload_rx_mon_ver_part2;
-	ubx_payload_rx_ack_ack_t		payload_rx_ack_ack;
-	ubx_payload_rx_ack_nak_t		payload_rx_ack_nak;
-	ubx_payload_tx_cfg_prt_t		payload_tx_cfg_prt;
-	ubx_payload_tx_cfg_rate_t		payload_tx_cfg_rate;
-	ubx_payload_tx_cfg_nav5_t		payload_tx_cfg_nav5;
-	ubx_payload_tx_cfg_rst_t		payload_tx_cfg_rst;
-	ubx_payload_tx_cfg_sbas_t		payload_tx_cfg_sbas;
-	ubx_payload_tx_cfg_msg_t		payload_tx_cfg_msg;
-	ubx_payload_tx_cfg_tmode3_t		payload_tx_cfg_tmode3;
-	ubx_payload_tx_cfg_cfg_t		payload_tx_cfg_cfg;
-	ubx_payload_tx_cfg_valset_t		payload_tx_cfg_valset;
+	ubx_payload_rx_nav_pvt_t          payload_rx_nav_pvt;
+	ubx_payload_rx_nav_posllh_t       payload_rx_nav_posllh;
+	ubx_payload_rx_nav_sol_t          payload_rx_nav_sol;
+	ubx_payload_rx_nav_dop_t          payload_rx_nav_dop;
+	ubx_payload_rx_nav_timeutc_t      payload_rx_nav_timeutc;
+	ubx_payload_rx_nav_svinfo_part1_t payload_rx_nav_svinfo_part1;
+	ubx_payload_rx_nav_svinfo_part2_t payload_rx_nav_svinfo_part2;
+	ubx_payload_rx_nav_sat_part1_t    payload_rx_nav_sat_part1;
+	ubx_payload_rx_nav_sat_part2_t    payload_rx_nav_sat_part2;
+	ubx_payload_rx_nav_svin_t         payload_rx_nav_svin;
+	ubx_payload_rx_nav_velned_t       payload_rx_nav_velned;
+	ubx_payload_rx_mon_hw_ubx6_t      payload_rx_mon_hw_ubx6;
+	ubx_payload_rx_mon_hw_ubx7_t      payload_rx_mon_hw_ubx7;
+	ubx_payload_rx_mon_rf_t           payload_rx_mon_rf;
+	ubx_payload_rx_mon_ver_part1_t    payload_rx_mon_ver_part1;
+	ubx_payload_rx_mon_ver_part2_t    payload_rx_mon_ver_part2;
+	ubx_payload_rx_ack_ack_t          payload_rx_ack_ack;
+	ubx_payload_rx_ack_nak_t          payload_rx_ack_nak;
+	ubx_payload_tx_cfg_prt_t          payload_tx_cfg_prt;
+	ubx_payload_tx_cfg_rate_t         payload_tx_cfg_rate;
+	ubx_payload_tx_cfg_nav5_t         payload_tx_cfg_nav5;
+	ubx_payload_tx_cfg_rst_t          payload_tx_cfg_rst;
+	ubx_payload_tx_cfg_sbas_t         payload_tx_cfg_sbas;
+	ubx_payload_tx_cfg_msg_t          payload_tx_cfg_msg;
+	ubx_payload_tx_cfg_tmode3_t       payload_tx_cfg_tmode3;
+	ubx_payload_tx_cfg_cfg_t          payload_tx_cfg_cfg;
+	ubx_payload_tx_cfg_valset_t       payload_tx_cfg_valset;
 } ubx_buf_t;
 
 #pragma pack(pop)
@@ -760,7 +760,6 @@ typedef enum {
 	UBX_ACK_GOT_ACK,
 	UBX_ACK_GOT_NAK
 } ubx_ack_state_t;
-
 
 class GPSDriverUBX : public GPSBaseStationSupport
 {

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -909,36 +909,40 @@ private:
 		u_blox9_F9P = 10, ///< F9P
 	};
 
-	const Interface		_interface;
+	const Interface _interface{};
 
-	sensor_gps_s *_gps_position {nullptr};
-	satellite_info_s *_satellite_info {nullptr};
-	uint64_t		_last_timestamp_time{0};
-	bool			_configured{false};
-	ubx_ack_state_t		_ack_state{UBX_ACK_IDLE};
-	bool			_got_posllh{false};
-	bool			_got_velned{false};
-	ubx_decode_state_t	_decode_state{};
-	uint16_t		_rx_msg{};
-	ubx_rxmsg_state_t	_rx_state{UBX_RXMSG_IGNORE};
-	uint16_t		_rx_payload_length{};
-	uint16_t		_rx_payload_index{};
-	uint8_t			_rx_ck_a{};
-	uint8_t			_rx_ck_b{};
-	gps_abstime		_disable_cmd_last{0};
-	uint16_t		_ack_waiting_msg{0};
-	ubx_buf_t		_buf{};
-	uint32_t		_ubx_version{0};
-	bool			_use_nav_pvt{false};
-	bool			_proto_ver_27_or_higher{false}; ///< true if protocol version 27 or higher detected
-	OutputMode		_output_mode{OutputMode::GPS};
+	gps_abstime             _disable_cmd_last{0};
+	sensor_gps_s*           _gps_position {nullptr};
+	satellite_info_s*       _satellite_info {nullptr};
+	ubx_ack_state_t         _ack_state{UBX_ACK_IDLE};
+	ubx_buf_t               _buf{};
+	ubx_decode_state_t      _decode_state{};
+	ubx_rxmsg_state_t       _rx_state{UBX_RXMSG_IGNORE};
 
-	RTCMParsing	*_rtcm_parsing{nullptr};
+	bool _configured{false};
+	bool _got_posllh{false};
+	bool _got_velned{false};
+	bool _proto_ver_27_or_higher{false}; ///< true if protocol version 27 or higher detected
+	bool _use_nav_pvt{false};
 
-	Board			_board{Board::unknown};
+	uint8_t _rx_ck_a{0};
+	uint8_t _rx_ck_b{0};
+	uint8_t _dyn_model{7};  ///< ublox Dynamic platform model default 7: airborne with <2g acceleration
 
-	// ublox Dynamic platform model default 7: airborne with <2g acceleration
-	uint8_t _dyn_model{7};
+	uint16_t _ack_waiting_msg{0};
+	uint16_t _rx_msg{};
+	uint16_t _rx_payload_index{0};
+	uint16_t _rx_payload_length{0};
+
+	uint32_t _ubx_version{0};
+
+	uint64_t _last_timestamp_time{0};
+
+	Board _board{Board::unknown};
+
+	OutputMode _output_mode{OutputMode::GPS};
+
+	RTCMParsing* _rtcm_parsing{nullptr};
 };
 
 

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -49,6 +49,11 @@
 
 #pragma once
 
+#include "base_station.h"
+#include "gps_helper.h"
+#include "../../definitions.h"
+
+
 #define UBX_CONFIG_TIMEOUT    250 // ms, timeout for waiting ACK
 #define UBX_PACKET_TIMEOUT    2   // ms, if now data during this delay assume that full update received
 

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -49,9 +49,13 @@
 
 #pragma once
 
-#include "gps_helper.h"
-#include "base_station.h"
-#include "../../definitions.h"
+#define UBX_CONFIG_TIMEOUT    250 // ms, timeout for waiting ACK
+#define UBX_PACKET_TIMEOUT    2   // ms, if now data during this delay assume that full update received
+
+#define DISABLE_MSG_INTERVAL  1000000    // us, try to disable message with this interval
+
+#define FNV1_32_INIT          static_cast<uint32_t>(0x811c9dc5)    // init value for FNV1 hash algorithm
+#define FNV1_32_PRIME         static_cast<uint32_t>(0x01000193)    // magic prime for FNV1 hash algorithm
 
 #define UBX_SYNC1             0xB5
 #define UBX_SYNC2             0x62


### PR DESCRIPTION
Hello,

This PR accomplishes a bit of cleanup and functionality in the following:
 - The Satellite PRN code field has been added in the Ashtek and uBlox drivers and the field order in the drivers now matches the message field list order,
 - C-style casts have been replaced with static_casts<>(),
 - Whitespace formatting has been standardized to be self-consistent within the header files,
 - Variable lists have been alphabetized/organized to be more easily readable to the extent allowed by initialization orders,


This PR has been bench tested on a Holybro pixhawk 4 and pixhawk 4 gps module.

Please let me know if you have any questions on this PR.  Thanks!

-Mark

